### PR TITLE
CRUD for matchups

### DIFF
--- a/ladder.cabal
+++ b/ladder.cabal
@@ -61,6 +61,7 @@ test-suite ladder-test
                      , HUnit
                      , bytestring >= 0.10.8.2 && < 0.11
                      , postgresql-simple >= 0.5.4.0 && < 0.6
+                     , time >= 1.8.0.2 && < 1.9
                      , uuid >= 1.3.13 && < 1.4
   other-modules:       Config
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/ladder.cabal
+++ b/ladder.cabal
@@ -22,6 +22,7 @@ library
                      , Data.Ladder.Time
                      , Data.Ladder.Venue
                      , Database.Ladder
+                     , Database.Ladder.Matchup
                      , Database.Ladder.Player
                      , Database.Ladder.Season
                      , Database.Ladder.Venue

--- a/migrations/2018-12-25T20:45:37_move-venue-to-matchups.sql
+++ b/migrations/2018-12-25T20:45:37_move-venue-to-matchups.sql
@@ -1,0 +1,11 @@
+-- rambler up
+
+ALTER TABLE matchups ADD COLUMN venue uuid REFERENCES venues(id);
+UPDATE matchups SET venue = matches.venue FROM matches WHERE matchups.id = matches.matchup;
+ALTER TABLE matches DROP COLUMN venue;
+
+-- rambler down
+
+ALTER TABLE matches ADD COLUMN venue uuid REFERENCES venues(id);
+UPDATE matches SET venue = matchups.venue FROM matchups WHERE matches.matchup = matchups.id;
+ALTER TABLE matchups DROP COLUMN venue;

--- a/migrations/2018-12-25T20:51:09_move-date-to-matchups.sql
+++ b/migrations/2018-12-25T20:51:09_move-date-to-matchups.sql
@@ -1,0 +1,8 @@
+-- rambler up
+
+ALTER TABLE matchups ADD COLUMN date timestamp with time zone;
+UPDATE matchups SET date = matches.start_time FROM matches where matches.matchup = matchups.id;
+
+-- rambler down
+
+ALTER TABLE matchups DROP COLUMN date;

--- a/scripts/test
+++ b/scripts/test
@@ -15,7 +15,7 @@ then
         usage
     else
         export PATH="$(pwd)":"$PATH"
-        rambler -c rambler.json.test apply
+        rambler -c rambler.json.test apply -a
         # test result stored instead of set -e for error-handling "finally"-like execution
         stack --no-terminal test --haddock --no-haddock-deps
         testResult="$?"

--- a/src/Data/Ladder/Match.hs
+++ b/src/Data/Ladder/Match.hs
@@ -5,8 +5,7 @@ import           Data.UUID        (UUID)
 
 data Match = Match { matchID     :: UUID
                    , matchup     :: UUID
-                   , venue       :: UUID
-                   , date        :: Time.SqlTime
+                   , startTime   :: Time.SqlTime
                    , recorded    :: Time.SqlTime
                    , player1Wins :: Int
                    , player2Wins :: Int }

--- a/src/Data/Ladder/Matchup.hs
+++ b/src/Data/Ladder/Matchup.hs
@@ -1,9 +1,18 @@
-module Data.Ladder.Matchup ( Matchup ) where
+module Data.Ladder.Matchup ( Matchup (..) ) where
 
-import           Data.UUID (UUID)
+import qualified Data.Ladder.Time                   as Time
+import           Data.UUID                          (UUID)
+import qualified Database.PostgreSQL.Simple.FromRow as Postgres
+import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
+import           GHC.Generics                       (Generic)
 
-data Matchup = Matchup { matchupID      :: UUID
-                       , player1        :: UUID
-                       , player2        :: UUID
-                       , week           :: Int
-                       , season         :: UUID }
+data Matchup = Matchup { matchupID :: UUID
+                       , player1   :: UUID
+                       , player2   :: UUID
+                       , week      :: Int
+                       , season    :: UUID
+                       , date      :: Maybe Time.SqlTime
+                       , venue     :: Maybe UUID } deriving (Eq, Show, Generic)
+
+instance Postgres.ToRow Matchup
+instance Postgres.FromRow Matchup

--- a/src/Data/Ladder/Season.hs
+++ b/src/Data/Ladder/Season.hs
@@ -3,7 +3,7 @@ module Data.Ladder.Season (Season(..)) where
 import qualified Data.Ladder.Time                   as Time
 import           Data.UUID                          (UUID)
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
-import qualified Database.PostgreSQL.Simple.ToRow as Postgres
+import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
 import           GHC.Generics                       (Generic)
 
 data Season = Season { seasonID :: UUID

--- a/src/Data/Ladder/Season.hs
+++ b/src/Data/Ladder/Season.hs
@@ -6,7 +6,7 @@ import qualified Database.PostgreSQL.Simple.FromRow as Postgres
 import qualified Database.PostgreSQL.Simple.ToRow as Postgres
 import           GHC.Generics                       (Generic)
 
-data Season = Season { seasonId :: UUID
+data Season = Season { seasonID :: UUID
                      , year     :: Int
                      , session  :: Time.Session } deriving (Eq, Show, Generic)
 

--- a/src/Data/Ladder/Time.hs
+++ b/src/Data/Ladder/Time.hs
@@ -5,15 +5,14 @@ module Data.Ladder.Time ( DayOfWeek (..)
                         , toUTCTime ) where
 
 import qualified Data.ByteString.Char8                as B
-import           Data.Time.Clock                      (getCurrentTime, UTCTime)
-import           Data.Time.LocalTime                  ( utc
-                                                      , utcToZonedTime
-                                                      , zonedTimeToUTC
-                                                      , zonedTimeToLocalTime
-                                                      , ZonedTime)
+import           Data.Time.Clock                      (UTCTime, getCurrentTime)
+import           Data.Time.LocalTime                  (ZonedTime, utc,
+                                                       utcToZonedTime,
+                                                       zonedTimeToLocalTime,
+                                                       zonedTimeToUTC)
 import qualified Database.PostgreSQL.Simple.FromField as Postgres
-import           Database.PostgreSQL.Simple.Time      (ZonedTimestamp,
-                                                       Unbounded (..),
+import           Database.PostgreSQL.Simple.Time      (Unbounded (..),
+                                                       ZonedTimestamp,
                                                        zonedTimestampToBuilder)
 import qualified Database.PostgreSQL.Simple.ToField   as Postgres
 
@@ -80,4 +79,4 @@ now = SqlTime . Finite <$> (utcToZonedTime utc <$> getCurrentTime)
 
 toUTCTime :: SqlTime -> Maybe UTCTime
 toUTCTime (SqlTime (Finite t)) = zonedTimeToUTC <$> Just t
-toUTCTime (SqlTime _) = Nothing
+toUTCTime (SqlTime _)          = Nothing

--- a/src/Database/Ladder/Matchup.hs
+++ b/src/Database/Ladder/Matchup.hs
@@ -6,7 +6,7 @@ module Database.Ladder.Matchup ( getMatchup
 
 import           Data.Int                         (Int64)
 import           Data.Ladder.Matchup
-import qualified Data.Ladder.Time as Time
+import qualified Data.Ladder.Time                 as Time
 import           Data.UUID                        (UUID)
 import qualified Database.Ladder                  as Database
 import qualified Database.PostgreSQL.Simple       as Postgres
@@ -37,7 +37,7 @@ scheduleMatchup handle matchup =
   in
     case (venue matchup, date matchup) of
       (Just venueID, Just date) ->
-        Postgres.execute (Database.conn handle) updateQuery (venueID, date)
+        Postgres.execute (Database.conn handle) updateQuery (date, venueID, matchupID matchup)
       _ ->
         pure 0
 
@@ -53,7 +53,7 @@ listMatchupsForPlayer handle playerID =
   let
     listQuery = [sql|SELECT id, player1, player2, week, season, date, venue
                     FROM matchups
-                    WHERE (player1 = ? OR player2 = ?) AND date > now();|]
+                    WHERE (player1 = ? OR player2 = ?) AND (date > now() OR date IS NULL);|]
   in
     Postgres.query (Database.conn handle) listQuery (playerID, playerID)
 

--- a/src/Database/Ladder/Matchup.hs
+++ b/src/Database/Ladder/Matchup.hs
@@ -1,0 +1,59 @@
+module Database.Ladder.Matchup ( getMatchup
+                               , createMatchup
+                               , scheduleMatchup
+                               , deleteMatchup
+                               , listMatchupsForPlayer ) where
+
+import           Data.Int                         (Int64)
+import           Data.Ladder.Matchup
+import qualified Data.Ladder.Time as Time
+import           Data.UUID                        (UUID)
+import qualified Database.Ladder                  as Database
+import qualified Database.PostgreSQL.Simple       as Postgres
+import           Database.PostgreSQL.Simple.SqlQQ
+
+getMatchup :: Database.Handle -> UUID -> IO [Matchup]
+getMatchup handle matchupID =
+  let
+    fetchQuery = [sql|SELECT id, player1, player2, week, season, date, venue
+                     FROM matchups
+                     WHERE id = ?;|]
+  in
+    Postgres.query (Database.conn handle) fetchQuery (Postgres.Only matchupID)
+
+createMatchup :: Database.Handle -> Matchup -> IO [Matchup]
+createMatchup handle matchup =
+  let
+    insertQuery = [sql|INSERT INTO matchups (id, player1, player2, week, season, date, venue)
+                      VALUES (?, ?, ?, ?, ?, ?, ?)
+                      RETURNING id, player1, player2, week, season, date, venue; |]
+  in
+    Postgres.query (Database.conn handle) insertQuery matchup
+
+scheduleMatchup :: Database.Handle -> Matchup -> IO Int64
+scheduleMatchup handle matchup =
+  let
+    updateQuery = [sql|UPDATE matchups SET date = ?, venue = ? WHERE id = ?;|]
+  in
+    case (venue matchup, date matchup) of
+      (Just venueID, Just date) ->
+        Postgres.execute (Database.conn handle) updateQuery (venueID, date)
+      _ ->
+        pure 0
+
+deleteMatchup :: Database.Handle -> Matchup -> IO Int64
+deleteMatchup handle matchup =
+  let
+    deleteQuery = [sql|DELETE FROM matchups WHERE id = ?;|]
+  in
+    Postgres.execute (Database.conn handle) deleteQuery (Postgres.Only $ matchupID matchup)
+
+listMatchupsForPlayer :: Database.Handle -> UUID -> IO [Matchup]
+listMatchupsForPlayer handle playerID =
+  let
+    listQuery = [sql|SELECT id, player1, player2, week, season, date, venue
+                    FROM matchups
+                    WHERE (player1 = ? OR player2 = ?) AND date > now();|]
+  in
+    Postgres.query (Database.conn handle) listQuery (playerID, playerID)
+


### PR DESCRIPTION
Overview
-----

This PR adds CRUD for matchups, now that venues are done

Testing
-----

- uncomment the commented test for updating the date
- run tests
- assure yourself that a failure at the level of picosecond resolution in haskell vs postgresql is ok

Closes #3 