### PR TITLE
Add database CRUD for matches

### DIFF
--- a/ladder.cabal
+++ b/ladder.cabal
@@ -23,6 +23,7 @@ library
                      , Data.Ladder.Time
                      , Data.Ladder.Venue
                      , Database.Ladder
+                     , Database.Ladder.Match
                      , Database.Ladder.Matchup
                      , Database.Ladder.Player
                      , Database.Ladder.Rating

--- a/migrations/2018-12-23T16:51:25_dbinit.sql
+++ b/migrations/2018-12-23T16:51:25_dbinit.sql
@@ -53,8 +53,8 @@ CREATE TABLE matches (
   venue uuid references venues(id) not null,
   start_time timestamp with time zone not null,
   recorded timestamp with time zone not null,
-  player1wins int not null,
-  player2ins int not null
+  player1_wins int not null,
+  player2_wins int not null
 );
 
 CREATE TABLE ratings (

--- a/migrations/2018-12-27T01:37:48_add-validation-to-matches.sql
+++ b/migrations/2018-12-27T01:37:48_add-validation-to-matches.sql
@@ -1,0 +1,12 @@
+-- rambler up
+
+ALTER TABLE matches
+ADD COLUMN validated bool NOT NULL,
+ADD COLUMN submitted_by uuid REFERENCES players(id);
+
+-- rambler down
+
+ALTER TABLE matches
+DROP COLUMN validated,
+DROP COLUMN submitted_by;
+

--- a/migrations/2018-12-27T03:27:28_cascade-matchup-deletions.sql
+++ b/migrations/2018-12-27T03:27:28_cascade-matchup-deletions.sql
@@ -1,0 +1,16 @@
+-- rambler up
+
+ALTER TABLE matches DROP CONSTRAINT matches_matchup_fkey;
+ALTER TABLE matches
+  ADD CONSTRAINT matches_matchup_fkey
+  FOREIGN KEY (matchup)
+  REFERENCES matchups(id)
+  ON DELETE CASCADE;
+
+-- rambler down
+
+ALTER TABLE matches DROP CONSTRAINT matches_matchup_fkey;
+ALTER TABLE matches
+  ADD CONSTRAINT matches_matchup_fkey
+  FOREIGN KEY (matchup)
+  REFERENCES matchups(id);

--- a/src/Data/Ladder/Match.hs
+++ b/src/Data/Ladder/Match.hs
@@ -27,11 +27,11 @@ data MatchWithRelated = MatchWithRelated { _matchID     :: UUID
                                          , _player1Wins :: Int
                                          , _player2Wins :: Int
                                          , _validated   :: Bool
-                                         , _submittedBy :: Bool
+                                         , _submittedBy :: UUID
                                          , season       :: UUID
                                          , week         :: Int
-                                         , date         :: Maybe Time.SqlTime
-                                         , venue        :: Maybe UUID } deriving (Eq, Show, Generic)
+                                         , matchupDate  :: Maybe Time.SqlTime
+                                         , matchupVenue :: Maybe UUID } deriving (Eq, Show, Generic)
 
 instance Postgres.ToRow MatchWithRelated
 instance Postgres.FromRow MatchWithRelated

--- a/src/Data/Ladder/Match.hs
+++ b/src/Data/Ladder/Match.hs
@@ -1,4 +1,6 @@
-module Data.Ladder.Match ( Match ) where
+module Data.Ladder.Match ( Match (..)
+                         , MatchWithRelated (..)
+                         , matchToUpdate ) where
 
 import qualified Data.Ladder.Time                   as Time
 import           Data.UUID                          (UUID)
@@ -18,3 +20,29 @@ data Match = Match { matchID     :: UUID
 
 instance Postgres.ToRow Match
 instance Postgres.FromRow Match
+
+data MatchWithRelated = MatchWithRelated { _matchID     :: UUID
+                                         , _startTime   :: Time.SqlTime
+                                         , _recorded    :: Time.SqlTime
+                                         , _player1Wins :: Int
+                                         , _player2Wins :: Int
+                                         , _validated   :: Bool
+                                         , _submittedBy :: Bool
+                                         , season       :: UUID
+                                         , week         :: Int
+                                         , date         :: Maybe Time.SqlTime
+                                         , venue        :: Maybe UUID } deriving (Eq, Show, Generic)
+
+instance Postgres.ToRow MatchWithRelated
+instance Postgres.FromRow MatchWithRelated
+
+data MatchUpdate = MatchUpdate { newPlayer1Wins :: Int
+                               , newPlayer2Wins :: Int
+                               , _matchID'      :: UUID } deriving (Eq, Show, Generic)
+
+instance Postgres.ToRow MatchUpdate
+
+matchToUpdate :: Match -> MatchUpdate
+matchToUpdate match = MatchUpdate { newPlayer1Wins = player1Wins match
+                                  , newPlayer2Wins = player2Wins match
+                                  , _matchID' = matchID match }

--- a/src/Data/Ladder/Match.hs
+++ b/src/Data/Ladder/Match.hs
@@ -1,11 +1,20 @@
 module Data.Ladder.Match ( Match ) where
 
-import qualified Data.Ladder.Time as Time
-import           Data.UUID        (UUID)
+import qualified Data.Ladder.Time                   as Time
+import           Data.UUID                          (UUID)
+import qualified Database.PostgreSQL.Simple.FromRow as Postgres
+import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
+import           GHC.Generics                       (Generic)
+
 
 data Match = Match { matchID     :: UUID
                    , matchup     :: UUID
                    , startTime   :: Time.SqlTime
                    , recorded    :: Time.SqlTime
                    , player1Wins :: Int
-                   , player2Wins :: Int }
+                   , player2Wins :: Int
+                   , validated   :: Bool
+                   , submittedBy :: UUID } deriving (Eq, Show, Generic)
+
+instance Postgres.ToRow Match
+instance Postgres.FromRow Match

--- a/src/Database/Ladder/Match.hs
+++ b/src/Database/Ladder/Match.hs
@@ -1,0 +1,92 @@
+module Database.Ladder.Match ( getMatch
+                             , submitMatch
+                             , updateMatch ) where
+
+import           Data.Int                         (Int64)
+import           Data.Ladder.Match
+import           Data.UUID                        (UUID)
+import qualified Database.Ladder                  as Database
+import qualified Database.PostgreSQL.Simple       as Postgres
+import           Database.PostgreSQL.Simple.SqlQQ
+import           Error
+
+checkSubmission :: Database.Handle -> Match -> IO (Either Message (Maybe (Int, Int)))
+checkSubmission handle match =
+  let
+    existingMatchQuery = [sql|SELECT player1wins, player2wins
+                             FROM matches
+                             WHERE matchup = ? and submitted_by <> ?; |]
+    existingSubmissionQuery = [sql|select 1, 1
+                                  FROM matches
+                                  WHERE matchup = ? and submitted_by = ?; |]
+    priorWinLossIO = (\x -> case x of
+                         []      -> Right Nothing
+                         [p]     -> Right $ Just p
+                         x1:x2:_ -> Left NotYourMatch
+                     ) <$>
+                     Postgres.query (Database.conn handle)
+                     existingMatchQuery
+                     (matchup match, submittedBy match)
+    -- This has a stupid type and query, but simple-postgresql is happier with tuples than with single values
+    priorUserSubmissionIO = (
+      \x -> case x of
+          [] -> Right ()
+          _  -> Left MatchAlreadySubmitted
+      ) <$>
+      ((Postgres.query (Database.conn handle)
+        existingSubmissionQuery
+        (matchup match, submittedBy match))
+       :: IO [(Int64, Int64)])
+  in
+    do
+      priorUserSubmit <- priorUserSubmissionIO
+      case priorUserSubmit of
+        Left e ->
+          pure $ Left e
+        _ ->
+          priorWinLossIO
+
+getMatch :: Database.Handle -> UUID -> IO [MatchWithRelated]
+getMatch handle matchID =
+  let
+    fetchQuery = [sql|SELECT id, start_time, recorded, match1wins, match2wins,
+                     validated, submitted_by, season, week, date, venue
+                     FROM matches join matchups on matches.matchup = matchups.id
+                     WHERE matches.id = ?;|]
+  in
+    Postgres.query (Database.conn handle) fetchQuery (Postgres.Only matchID)
+
+submitMatch :: Database.Handle -> Match -> IO (Either Message [Match])
+submitMatch handle match =
+  let
+    insertQuery = [sql|INSERT INTO matches (id, matchup, start_time, recorded, player1wins,
+                      player2wins, validated, submitted_by
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                      RETURNING id, matchup, start_time, recorded,
+                      player1wins, player2wins, validated, submitted_by;|]
+  in
+    do
+      validation <- checkSubmission handle match
+      case validation of
+        Right Nothing ->
+          Right <$> Postgres.query (Database.conn handle) insertQuery (match { validated = False })
+        Right (Just prior) ->
+          Right <$> Postgres.query (Database.conn handle) insertQuery
+            (match { validated = prior == (player1Wins match, player2Wins match)})
+        (Left e) ->
+          pure $ Left e
+
+updateMatch :: Database.Handle -> Match -> IO Int64
+updateMatch handle match =
+  let
+    updateQuery = [sql|UPDATE matches
+                      SET player1Wins = ?, player2Wins = ?
+                      WHERE id = ?;|]
+  in
+    do
+      validation <- checkSubmission handle match
+      case validation of
+        -- using a left as a success case? You bet! I'm ashamed, no one look at this line
+        Left MatchAlreadySubmitted ->
+          Postgres.execute (Database.conn handle) updateQuery (matchToUpdate match)
+        _ -> pure 0

--- a/src/Database/Ladder/Match.hs
+++ b/src/Database/Ladder/Match.hs
@@ -13,7 +13,7 @@ import           Error
 checkSubmission :: Database.Handle -> Match -> IO (Either Message (Maybe (Int, Int)))
 checkSubmission handle match =
   let
-    existingMatchQuery = [sql|SELECT player1wins, player2wins
+    existingMatchQuery = [sql|SELECT player1_wins, player2_wins
                              FROM matches
                              WHERE matchup = ? and submitted_by <> ?; |]
     existingSubmissionQuery = [sql|select 1, 1
@@ -49,7 +49,7 @@ checkSubmission handle match =
 getMatch :: Database.Handle -> UUID -> IO [MatchWithRelated]
 getMatch handle matchID =
   let
-    fetchQuery = [sql|SELECT id, start_time, recorded, match1wins, match2wins,
+    fetchQuery = [sql|SELECT matches.id, start_time, recorded, player1_wins, player2_wins,
                      validated, submitted_by, season, week, date, venue
                      FROM matches join matchups on matches.matchup = matchups.id
                      WHERE matches.id = ?;|]
@@ -59,11 +59,14 @@ getMatch handle matchID =
 submitMatch :: Database.Handle -> Match -> IO (Either Message [Match])
 submitMatch handle match =
   let
-    insertQuery = [sql|INSERT INTO matches (id, matchup, start_time, recorded, player1wins,
-                      player2wins, validated, submitted_by
+    insertQuery = [sql|INSERT INTO matches (id, matchup, start_time, recorded, player1_wins,
+                      player2_wins, validated, submitted_by)
                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                       RETURNING id, matchup, start_time, recorded,
-                      player1wins, player2wins, validated, submitted_by;|]
+                      player1_wins, player2_wins, validated, submitted_by;|]
+    updateOtherMatchQuery = [sql|UPDATE matches
+                                SET validated = true
+                                WHERE matchup = ? and submitted_by <> ?;|]
   in
     do
       validation <- checkSubmission handle match
@@ -71,8 +74,11 @@ submitMatch handle match =
         Right Nothing ->
           Right <$> Postgres.query (Database.conn handle) insertQuery (match { validated = False })
         Right (Just prior) ->
-          Right <$> Postgres.query (Database.conn handle) insertQuery
-            (match { validated = prior == (player1Wins match, player2Wins match)})
+          Right <$> if (prior == (player1Wins match, player2Wins match)) then
+                      Postgres.query (Database.conn handle) insertQuery (match { validated = True }) <*
+                      Postgres.execute (Database.conn handle) updateOtherMatchQuery (matchup match, submittedBy match)
+                    else
+                      Postgres.query (Database.conn handle) insertQuery (match { validated = False })
         (Left e) ->
           pure $ Left e
 
@@ -80,13 +86,28 @@ updateMatch :: Database.Handle -> Match -> IO Int64
 updateMatch handle match =
   let
     updateQuery = [sql|UPDATE matches
-                      SET player1Wins = ?, player2Wins = ?
-                      WHERE id = ?;|]
+                      SET player1_Wins = ?, player2_Wins = ?
+                      WHERE id = ? AND validated = false;|]
+    shouldValidate = [sql|SELECT player1_wins, player2_wins, COUNT(1)
+                         FROM matches
+                         WHERE matchup = ?
+                         GROUP BY (player1_wins, player2_wins); |]
+    validateMatches = [sql|UPDATE matches SET validated = true
+                          WHERE matchup = ?; |]
   in
     do
       validation <- checkSubmission handle match
-      case validation of
-        -- using a left as a success case? You bet! I'm ashamed, no one look at this line
-        Left MatchAlreadySubmitted ->
-          Postgres.execute (Database.conn handle) updateQuery (matchToUpdate match)
-        _ -> pure 0
+      nUpdated <- case validation of
+                    -- using a left as a success case? You bet! I'm ashamed, no one look at this line
+                    Left MatchAlreadySubmitted ->
+                      Postgres.execute (Database.conn handle) updateQuery (matchToUpdate match)
+                    _ -> pure 0
+      distinctScores <- (
+        Postgres.query (Database.conn handle) shouldValidate (Postgres.Only $ matchup match))
+        :: IO [(Int, Int, Int)]
+      case distinctScores of
+        [(_, _, 2)] ->
+          Postgres.execute (Database.conn handle) validateMatches (Postgres.Only $ matchup match) *>
+          pure nUpdated
+        _ ->
+          pure nUpdated

--- a/src/Database/Ladder/Rating.hs
+++ b/src/Database/Ladder/Rating.hs
@@ -30,9 +30,10 @@ createRating handle rating =
 listRecentPlayerRatings :: Database.Handle -> UUID -> Int -> IO [Rating]
 listRecentPlayerRatings handle playerID nRecentWeeks =
   let
-    listQuery = [sql|SELECT id, season, week, rating, player
-                    FROM ratings
-                    ORDER BY season desc, week desc
+    listQuery = [sql|SELECT ratings.id, season, week, rating, player
+                    FROM ratings JOIN seasons ON ratings.season = seasons.id
+                    WHERE player = ?
+                    ORDER BY seasons.year desc, seasons.session desc, week desc
                     LIMIT ?;|]
   in
-    Postgres.query (Database.conn handle) listQuery (Postgres.Only nRecentWeeks)
+    Postgres.query (Database.conn handle) listQuery (playerID,  nRecentWeeks)

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -2,4 +2,6 @@ module Error (Message(..)) where
 
 data Message =
   UnbalancedMatch String
+  | NotYourMatch
+  | MatchAlreadySubmitted
   deriving (Eq, Show)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -60,6 +60,7 @@ dbSpec :: IO ()
 dbSpec = do
   seasonDBSpec
   playerDBSpec
+  ratingDBSpec
   venueDBSpec
   matchupDBSpec
 


### PR DESCRIPTION
Overview
-----

This PR adds DB CRUD for matches. It also runs db tests for ratings (oops) and fixes some fallout from that.

Woohoo no more (database) CRUD for a minute :tada:

Testing
-----

test

Closes #4 

Also might solve #6 but I need to think about it more