### PR TITLE
Add venue filtering and venue API basics

### DIFF
--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,34 @@
+module Config where
+
+import           Data.ByteString            (ByteString)
+import           Data.ByteString.Char8      (pack)
+import           Data.Maybe                 (fromMaybe)
+import           Database.Ladder            (Handle (..))
+import qualified Database.PostgreSQL.Simple as Postgres
+import           System.Environment         (lookupEnv)
+
+data Config = Config { connString :: ByteString } deriving (Show)
+
+defaultConfig :: IO Config
+defaultConfig = do
+  user <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_USER"
+  pass <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_PASSWORD"
+  host <- fromMaybe "localhost" <$> lookupEnv "POSTGRES_HOST"
+  port <- (read :: String -> Int) . fromMaybe "5432" <$> lookupEnv "POSTGRES_PORT"
+  name <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_NAME"
+  return . Config $
+    pack $
+    "postgresql://" ++ user ++
+    ":" ++
+    pass ++
+    "@" ++
+    host ++
+    ":" ++
+    show port ++
+    "/" ++
+    name
+
+defaultHandle :: IO Handle
+defaultHandle = do
+  cs <- connString <$> defaultConfig
+  Handle <$> Postgres.connectPostgreSQL cs

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,8 @@
 module Main where
 
+import Network.Wai
+import Network.Wai.Handler.Warp
+import Server
+
 main :: IO ()
-main = print "good job"
+main = run 8081 application

--- a/app/Server.hs
+++ b/app/Server.hs
@@ -1,0 +1,11 @@
+module Server where
+
+import Data.Ladder.Time
+import Server.Venue
+import Servant
+
+api :: Proxy VenueAPI
+api = Proxy
+
+application :: Application
+application = serve api venueServer

--- a/app/Server/Venue.hs
+++ b/app/Server/Venue.hs
@@ -1,0 +1,31 @@
+module Server.Venue where
+
+import Config (defaultHandle)
+import Control.Monad.IO.Class (MonadIO (..))
+import Data.Ladder.Venue
+import Data.Maybe (fromMaybe)
+import Database.Ladder.Venue
+import qualified Data.Ladder.Time as Time
+import qualified Database.PostgreSQL.Simple.Types as Postgres
+import Servant.Server
+import Servant
+
+import Data.UUID (UUID)
+
+type VenueAPI =
+  "venues" :> QueryParam "freeNights" [Time.DayOfWeek] :> Get '[JSON] [Venue]
+  -- :<|> "venues" :> Capture "venueID" UUID :> Get '[JSON] Venue
+  -- :<|> "venues" :> Put '[JSON] Int
+  -- :<|> "venues" :> Delete '[JSON] Int
+  -- :<|> "venues" :> PostCreated '[JSON] [Venue]
+
+venueListHandler :: Maybe [Time.DayOfWeek] -> Handler [Venue]
+venueListHandler maybeDaysOfWeek = do
+  handle <- liftIO defaultHandle
+  liftIO $ listVenues handle freeNights
+  where
+    freeNights =
+      Postgres.PGArray $ fromMaybe Time.allDaysOfWeek maybeDaysOfWeek
+
+venueServer :: Server VenueAPI
+venueServer = venueListHandler

--- a/app/Server/Venue.hs
+++ b/app/Server/Venue.hs
@@ -12,6 +12,8 @@ import Servant
 
 import Data.UUID (UUID)
 
+import Debug.Trace
+
 type VenueAPI =
   "venues" :> QueryParam "freeNights" [Time.DayOfWeek] :> Get '[JSON] [Venue]
   -- :<|> "venues" :> Capture "venueID" UUID :> Get '[JSON] Venue

--- a/ladder.cabal
+++ b/ladder.cabal
@@ -37,6 +37,7 @@ library
                      , servant-server
                      , postgresql-simple >= 0.5.4.0 && < 0.6
                      , statistics >= 0.14.0.2 && < 0.15
+                     , text
                      , time >= 1.8.0.2 && < 1.9
                      , uuid >= 1.3.13 && < 1.4
                      , wai
@@ -45,14 +46,29 @@ library
   default-extensions:  DeriveGeneric
                      , OverloadedStrings
                      , QuasiQuotes
+                     , DataKinds
+                     , FlexibleInstances
+                     , TypeOperators
 
 executable ladder-exe
   hs-source-dirs:      app
+  other-modules:       Config
+                     , Server
+                     , Server.Venue
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , ladder
+                     , servant-server
+                     , bytestring >= 0.10.8.2 && < 0.11
+                     , postgresql-simple >= 0.5.4.0 && < 0.6
+                     , servant-server
+                     , uuid >= 1.3.13 && < 1.4
+                     , wai
+                     , warp
   default-language:    Haskell2010
+  default-extensions:  DataKinds
+                     , TypeOperators
 
 test-suite ladder-test
   type:                exitcode-stdio-1.0

--- a/src/Data/Ladder/Matchup.hs
+++ b/src/Data/Ladder/Matchup.hs
@@ -1,4 +1,4 @@
-module Data.Ladder.Matchup ( Matchup (..) ) where
+module Data.Ladder.Matchup ( Matchup (..), VenueFilter (..) ) where
 
 import qualified Data.Ladder.Time                   as Time
 import           Data.UUID                          (UUID)
@@ -16,3 +16,8 @@ data Matchup = Matchup { matchupID :: UUID
 
 instance Postgres.ToRow Matchup
 instance Postgres.FromRow Matchup
+
+data VenueFilter = VenueFilter { dayOfWeek :: Time.SqlTime
+                               , venueID   :: UUID} deriving (Eq, Show, Generic)
+
+instance Postgres.ToRow VenueFilter

--- a/src/Data/Ladder/Time.hs
+++ b/src/Data/Ladder/Time.hs
@@ -1,6 +1,7 @@
 module Data.Ladder.Time ( DayOfWeek (..)
                         , Session(..)
                         , SqlTime(..)
+                        , dowComplement
                         , now
                         , toUTCTime ) where
 
@@ -22,7 +23,7 @@ data DayOfWeek = Monday
   | Thursday
   | Friday
   | Saturday
-  | Sunday deriving (Eq, Show)
+  | Sunday deriving (Eq, Show, Enum)
 
 dowFromString :: String -> DayOfWeek
 dowFromString "Monday"    = Monday
@@ -43,6 +44,10 @@ instance Postgres.FromField DayOfWeek where
       Nothing -> Postgres.returnError Postgres.UnexpectedNull f ""
       Just dat ->
         pure $ dowFromString dat
+
+dowComplement :: [DayOfWeek] -> [DayOfWeek]
+dowComplement days =
+  filter (not . (\x -> elem x days)) [Monday .. Sunday]
 
 data Session = Spring
   | Summer

--- a/src/Data/Ladder/Time.hs
+++ b/src/Data/Ladder/Time.hs
@@ -11,7 +11,7 @@ module Data.Ladder.Time ( DayOfWeek (..)
 import           Data.Aeson
 import qualified Data.ByteString.Char8                as B
 import           Data.Foldable                        (toList)
-import Data.Monoid ((<>))
+import           Data.Monoid                          ((<>))
 import qualified Data.Text                            as T
 import           Data.Time.Clock                      (UTCTime, getCurrentTime)
 import           Data.Time.LocalTime                  (ZonedTime, utc,
@@ -80,12 +80,11 @@ instance Postgres.FromField DayOfWeek where
 
 instance FromHttpApiData [DayOfWeek] where
   parseQueryParam t =
-    case T.breakOn "," t of
-      (v, "") ->
-        pure <$> dowFromStringE v
-      (v, w) ->
-        (++) <$> (pure <$> dowFromStringE v) <*> parseQueryParam w
-
+    go  (Right []) t
+    where
+      go (Left t) _ = Left t
+      go r@(Right days) text =
+        traverse dowFromStringE $ T.split (== ',') text
 
 allDaysOfWeek :: [DayOfWeek]
 allDaysOfWeek = [Monday .. Sunday]

--- a/src/Data/Ladder/Venue.hs
+++ b/src/Data/Ladder/Venue.hs
@@ -3,6 +3,7 @@ module Data.Ladder.Venue (Venue (..), venueToUpdate) where
 import qualified Data.Ladder.Time                   as Time
 import           Data.UUID                          (UUID)
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
+import qualified Database.PostgreSQL.Simple.ToField as Postgres
 import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
 import qualified Database.PostgreSQL.Simple.Types   as Postgres
 import           GHC.Generics                       (Generic)

--- a/src/Data/Ladder/Venue.hs
+++ b/src/Data/Ladder/Venue.hs
@@ -1,5 +1,6 @@
 module Data.Ladder.Venue (Venue (..), venueToUpdate) where
 
+import           Data.Aeson                         (FromJSON, ToJSON)
 import qualified Data.Ladder.Time                   as Time
 import           Data.UUID                          (UUID)
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
@@ -12,16 +13,19 @@ data Venue = Venue { venueID      :: UUID
                    , name         :: String
                    , phone        :: String
                    , address      :: String
-                   , leagueNights :: Postgres.PGArray Time.DayOfWeek
+                   , leagueNights :: Time.DaysOfWeek
                    , cost         :: Maybe Double } deriving (Eq, Show, Generic)
 
 instance Postgres.ToRow Venue
 instance Postgres.FromRow Venue
 
+instance ToJSON Venue
+instance FromJSON Venue
+
 data VenueUpdate = VenueUpdate { _name :: String
                                , _phone :: String
                                , _address :: String
-                               , _leagueNights :: Postgres.PGArray Time.DayOfWeek
+                               , _leagueNights :: Time.DaysOfWeek
                                , _cost :: Maybe Double
                                , _venueID :: UUID } deriving (Eq, Show, Generic)
 

--- a/src/Database/Ladder/Matchup.hs
+++ b/src/Database/Ladder/Matchup.hs
@@ -13,6 +13,8 @@ import qualified Database.Ladder                  as Database
 import qualified Database.PostgreSQL.Simple       as Postgres
 import           Database.PostgreSQL.Simple.SqlQQ
 
+import Debug.Trace
+
 getMatchup :: Database.Handle -> UUID -> IO [Matchup]
 getMatchup handle matchupID =
   let
@@ -65,4 +67,4 @@ listMatchupsAtVenue handle filter =
                     FROM matchups
                     WHERE date(date) = date(?) AND venue = ?;|]
   in
-    Postgres.query (Database.conn handle) listQuery filter
+    Postgres.query (Database.conn handle) listQuery ((trace $ "filters are " ++ show filter) filter)

--- a/src/Database/Ladder/Matchup.hs
+++ b/src/Database/Ladder/Matchup.hs
@@ -2,7 +2,8 @@ module Database.Ladder.Matchup ( getMatchup
                                , createMatchup
                                , scheduleMatchup
                                , deleteMatchup
-                               , listMatchupsForPlayer ) where
+                               , listMatchupsForPlayer
+                               , listMatchupsAtVenue ) where
 
 import           Data.Int                         (Int64)
 import           Data.Ladder.Matchup
@@ -57,3 +58,11 @@ listMatchupsForPlayer handle playerID =
   in
     Postgres.query (Database.conn handle) listQuery (playerID, playerID)
 
+listMatchupsAtVenue :: Database.Handle -> VenueFilter -> IO [Matchup]
+listMatchupsAtVenue handle filter =
+  let
+    listQuery = [sql|SELECT id, player1, player2, week, season, date, venue
+                    FROM matchups
+                    WHERE date(date) = date(?) AND venue = ?;|]
+  in
+    Postgres.query (Database.conn handle) listQuery filter

--- a/src/Database/Ladder/Venue.hs
+++ b/src/Database/Ladder/Venue.hs
@@ -47,13 +47,12 @@ deleteVenue handle venue =
   in
     Postgres.execute (Database.conn handle) deleteQuery (Postgres.Only $ venueID venue)
 
--- TODO how to do array disjoint in postgres?
 listVenues :: Database.Handle -> Postgres.PGArray Time.DayOfWeek -> IO [Venue]
 listVenues handle (Postgres.PGArray desiredNights) =
   let
     listQuery = [sql|SELECT id, name, phone, address, league_nights, cost
                     FROM venues
                     WHERE NOT (? :: day_of_week[]) <@ league_nights;|]
-    badNights = Postgres.PGArray $ Time.dowComplement desiredNights
+    badNights = Postgres.PGArray desiredNights
   in
     Postgres.query (Database.conn handle) listQuery (Postgres.Only badNights)

--- a/src/Database/Ladder/Venue.hs
+++ b/src/Database/Ladder/Venue.hs
@@ -5,11 +5,13 @@ module Database.Ladder.Venue ( getVenue
                              , listVenues ) where
 
 import           Data.Int                         (Int64)
+import qualified Data.Ladder.Time                 as Time
 import           Data.Ladder.Venue
 import           Data.UUID                        (UUID)
 import qualified Database.Ladder                  as Database
 import qualified Database.PostgreSQL.Simple       as Postgres
 import           Database.PostgreSQL.Simple.SqlQQ
+import qualified Database.PostgreSQL.Simple.Types as Postgres
 
 getVenue :: Database.Handle -> UUID -> IO [Venue]
 getVenue handle venueID =
@@ -33,7 +35,7 @@ updateVenue :: Database.Handle -> Venue -> IO Int64
 updateVenue handle venue =
   let
     updateQuery = [sql|UPDATE venues
-                      SET name = ?, phone = ?, address = ?, league_nights = ?, cost = ?
+                      SET name = ?, phone = ?, address = ?, league_nights = (? :: day_of_week[]), cost = ?
                       WHERE id = ?;|]
   in
     Postgres.execute (Database.conn handle) updateQuery (venueToUpdate venue)
@@ -45,9 +47,14 @@ deleteVenue handle venue =
   in
     Postgres.execute (Database.conn handle) deleteQuery (Postgres.Only $ venueID venue)
 
-listVenues :: Database.Handle -> IO [Venue]
-listVenues handle =
+-- TODO how to do array disjoint in postgres?
+listVenues :: Database.Handle -> Postgres.PGArray Time.DayOfWeek -> IO [Venue]
+listVenues handle (Postgres.PGArray desiredNights) =
   let
-    listQuery = [sql|SELECT id, name, phone, address, league_nights, cost FROM venues;|]
+    listQuery = [sql|SELECT id, name, phone, address,
+                    league_nights ^& (? :: day_of_week[]) free_nights, cost
+                    FROM venues
+                    WHERE free_nights <> ('{}' :: day_of_week[]) ;|]
+    badNights = Postgres.PGArray $ Time.dowComplement desiredNights
   in
-    Postgres.query_ (Database.conn handle) listQuery
+    Postgres.query (Database.conn handle) listQuery (Postgres.Only badNights)

--- a/src/Database/Ladder/Venue.hs
+++ b/src/Database/Ladder/Venue.hs
@@ -51,10 +51,9 @@ deleteVenue handle venue =
 listVenues :: Database.Handle -> Postgres.PGArray Time.DayOfWeek -> IO [Venue]
 listVenues handle (Postgres.PGArray desiredNights) =
   let
-    listQuery = [sql|SELECT id, name, phone, address,
-                    league_nights ^& (? :: day_of_week[]) free_nights, cost
+    listQuery = [sql|SELECT id, name, phone, address, league_nights, cost
                     FROM venues
-                    WHERE free_nights <> ('{}' :: day_of_week[]) ;|]
+                    WHERE NOT (? :: day_of_week[]) <@ league_nights;|]
     badNights = Postgres.PGArray $ Time.dowComplement desiredNights
   in
     Postgres.query (Database.conn handle) listQuery (Postgres.Only badNights)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -136,7 +136,7 @@ venueDBSpec = do
               "Quite Good and Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
-              (Postgres.PGArray [])
+              (Time.DaysOfWeek $ Postgres.PGArray [])
               (Just 10.75)) <$> UUIDv4.nextRandom
   inserted <- Venue.createVenue handle venue
   retrieved <- Venue.getVenue handle (Venue.venueID venue)
@@ -144,13 +144,13 @@ venueDBSpec = do
   assertEqual "return from insert is the player we inserted" inserted [venue]
   _ <- Venue.updateVenue handle (venue { Venue.name = "Actually Not a Fun Place"
                                        , Venue.leagueNights =
-                                         Postgres.PGArray [Time.Monday, Time.Tuesday] })
+                                         Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday] })
   fetchedAgain <- Venue.getVenue handle (Venue.venueID venue)
   assertEqual "update should have done something" fetchedAgain $
     [venue { Venue.name = "Actually Not a Fun Place"
-           , Venue.leagueNights = Postgres.PGArray [Time.Monday, Time.Tuesday]}]
+           , Venue.leagueNights = Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday]}]
   listed <- Venue.listVenues handle
-            (Postgres.PGArray [Time.Monday, Time.Tuesday])
+            (Postgres.PGArray [Time.Monday, Time.Wednesday])
   assertEqual "list should get the only venue we've created" listed fetchedAgain
   _ <- Venue.deleteVenue handle venue
   listedAgain <- Venue.listVenues handle
@@ -179,14 +179,14 @@ matchupDBSpec = do
               "Quite Good and Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
-              (Postgres.PGArray [Time.Monday, Time.Tuesday])
+              (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
               (Just 10.75)) <$> UUIDv4.nextRandom
   otherVenue <- (\venueID ->
               Venue.Venue venueID
               "Not Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
-              (Postgres.PGArray [Time.Monday, Time.Tuesday])
+              (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
               (Just 10.75)) <$> UUIDv4.nextRandom
   _ <- Season.createSeason handle season
   _ <- Player.createPlayer handle player1

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,21 +1,21 @@
 module Main (main) where
 
 import           Data.Int                         (Int64)
-import           Data.Ladder.Match
-import           Data.Ladder.Matchup
-import           Data.Ladder.Player
-import           Data.Ladder.Rating
-import           Data.Ladder.Season
-import           Data.Ladder.Time
-import           Data.Ladder.Venue
+import qualified Data.Ladder.Match                as Match
+import qualified Data.Ladder.Matchup              as Matchup
+import qualified Data.Ladder.Player               as Player
+import qualified Data.Ladder.Rating               as Rating
+import qualified Data.Ladder.Season               as Season
+import qualified Data.Ladder.Time                 as Time
+import qualified Data.Ladder.Venue                as Venue
 import qualified Data.UUID.V4                     as UUIDv4
 import qualified Database.Ladder                  as Database
-import           Database.Ladder.Match
-import           Database.Ladder.Matchup
-import           Database.Ladder.Player
-import           Database.Ladder.Rating
-import           Database.Ladder.Season
-import           Database.Ladder.Venue
+import qualified Database.Ladder.Match            as Match
+import qualified Database.Ladder.Matchup          as Matchup
+import qualified Database.Ladder.Player           as Player
+import qualified Database.Ladder.Rating           as Rating
+import qualified Database.Ladder.Season           as Season
+import qualified Database.Ladder.Venue            as Venue
 import qualified Database.PostgreSQL.Simple       as Postgres
 import           Database.PostgreSQL.Simple.SqlQQ
 import qualified Database.PostgreSQL.Simple.Types as Postgres
@@ -70,105 +70,151 @@ dbSpec = do
 seasonDBSpec :: Assertion
 seasonDBSpec = do
   handle <- defaultHandle
-  season <- (\seasonID -> Season seasonID 2019 Summer) <$> UUIDv4.nextRandom
-  created <- createSeason handle season
-  listed <- getCurrentSeason handle
+  season <- (\seasonID -> Season.Season seasonID 2019 Time.Summer) <$> UUIDv4.nextRandom
+  created <- Season.createSeason handle season
+  listed <- Season.getCurrentSeason handle
   assertEqual "return from created should match return from latest" created listed
   assertEqual "return from created should be the same as source season" created [season]
 
 playerDBSpec :: Assertion
 playerDBSpec = do
   handle <- defaultHandle
-  player <- (\playerID -> Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
-  inserted <- createPlayer handle player
-  retrieved <- getPlayer handle (playerID player)
+  player <- (\playerID -> Player.Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  inserted <- Player.createPlayer handle player
+  retrieved <- Player.getPlayer handle (Player.playerID player)
   assertEqual "return from fetch is the same as return from insert" inserted retrieved
   assertEqual "return from insert is the player we inserted" inserted [player]
-  _ <- updatePlayer handle (player { email = "bar@bogus.net" })
-  fetchedAgain <- getPlayer handle (playerID player)
-  assertEqual "the email was updated" (email <$> fetchedAgain) ["bar@bogus.net"]
-  _ <- deletePlayer handle player
-  fetchedAThirdTime <- getPlayer handle (playerID player)
+  _ <- Player.updatePlayer handle (player { Player.email = "bar@bogus.net" })
+  fetchedAgain <- Player.getPlayer handle (Player.playerID player)
+  assertEqual "the email was updated" (Player.email <$> fetchedAgain) ["bar@bogus.net"]
+  _ <- Player.deletePlayer handle player
+  fetchedAThirdTime <- Player.getPlayer handle (Player.playerID player)
   assertEqual "the player is gone from the db" fetchedAThirdTime []
 
 ratingDBSpec :: Assertion
 ratingDBSpec = do
   handle <- defaultHandle
-  player1 <- (\playerID -> Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
-  player2 <- (\playerID -> Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
-  season <- (\seasonID -> Season seasonID 2019 Summer) <$> UUIDv4.nextRandom
-  rating1 <- (\ratingID -> Rating ratingID (seasonID season) 1 1000 (playerID player1)) <$> UUIDv4.nextRandom
-  rating2 <- (\ratingID -> Rating ratingID (seasonID season) 2 1000 (playerID player1)) <$> UUIDv4.nextRandom
-  rating3 <- (\ratingID -> Rating ratingID (seasonID season) 3 1000 (playerID player1)) <$> UUIDv4.nextRandom
-  rating4 <- (\ratingID -> Rating ratingID (seasonID season) 3 1000 (playerID player2)) <$> UUIDv4.nextRandom
-  _ <- createPlayer handle player1
-  _ <- createPlayer handle player2
-  _ <- createSeason handle season
-  _ <- traverse (createRating handle) [rating1, rating2, rating3, rating4]
-  recentPlayer1 <- listRecentPlayerRatings handle (playerID player1) 3
+  player1 <- (\playerID -> Player.Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  player2 <- (\playerID -> Player.Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  season <- (\seasonID -> Season.Season seasonID 2019 Time.Summer) <$> UUIDv4.nextRandom
+  rating1 <- (\ratingID -> Rating.Rating ratingID
+               (Season.seasonID season)
+               1
+               1000
+               (Player.playerID player1)) <$> UUIDv4.nextRandom
+  rating2 <- (\ratingID -> Rating.Rating ratingID
+               (Season.seasonID season)
+               2
+               1000
+               (Player.playerID player1)) <$> UUIDv4.nextRandom
+  rating3 <- (\ratingID -> Rating.Rating ratingID
+               (Season.seasonID season)
+               3
+               1000
+               (Player.playerID player1)) <$> UUIDv4.nextRandom
+  rating4 <- (\ratingID -> Rating.Rating ratingID
+               (Season.seasonID season)
+               3
+               1000
+               (Player.playerID player2)) <$> UUIDv4.nextRandom
+  _ <- Player.createPlayer handle player1
+  _ <- Player.createPlayer handle player2
+  _ <- Season.createSeason handle season
+  _ <- traverse (Rating.createRating handle) [rating1, rating2, rating3, rating4]
+  recentPlayer1 <- Rating.listRecentPlayerRatings handle (Player.playerID player1) 3
   assertEqual "player1's ratings are all there" recentPlayer1 [rating3, rating2, rating1]
-  recentPlayer2 <- listRecentPlayerRatings handle (playerID player2) 3
+  recentPlayer2 <- Rating.listRecentPlayerRatings handle (Player.playerID player2) 3
   assertEqual "player2's ratings are all there" recentPlayer2 [rating4]
-  fetchedById <- getRating handle (ratingID rating2)
+  fetchedById <- Rating.getRating handle (Rating.ratingID rating2)
   assertEqual "selection by id is fine" fetchedById [rating2]
 
 venueDBSpec :: Assertion
 venueDBSpec = do
   handle <- defaultHandle
   venue <- (\venueID ->
-              Venue venueID
+              Venue.Venue venueID
               "Quite Good and Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
-              (Postgres.PGArray [Monday, Tuesday])
+              (Postgres.PGArray [])
               (Just 10.75)) <$> UUIDv4.nextRandom
-  inserted <- createVenue handle venue
-  retrieved <- getVenue handle (venueID venue)
+  inserted <- Venue.createVenue handle venue
+  retrieved <- Venue.getVenue handle (Venue.venueID venue)
   assertEqual "return from fetch is the same as return from insert" inserted retrieved
   assertEqual "return from insert is the player we inserted" inserted [venue]
-  _ <- updateVenue handle (venue { name = "Actually Not a Fun Place", leagueNights = Postgres.PGArray [] })
-  fetchedAgain <- getVenue handle (venueID venue)
+  _ <- Venue.updateVenue handle (venue { Venue.name = "Actually Not a Fun Place"
+                                       , Venue.leagueNights =
+                                         Postgres.PGArray [Time.Monday, Time.Tuesday] })
+  fetchedAgain <- Venue.getVenue handle (Venue.venueID venue)
   assertEqual "update should have done something" fetchedAgain $
-    [venue { name = "Actually Not a Fun Place", leagueNights = Postgres.PGArray []}]
-  listed <- listVenues handle
+    [venue { Venue.name = "Actually Not a Fun Place"
+           , Venue.leagueNights = Postgres.PGArray [Time.Monday, Time.Tuesday]}]
+  listed <- Venue.listVenues handle
+            (Venue.FreeNightFilter $ Postgres.PGArray [Time.Wednesday .. Time.Sunday])
   assertEqual "list should get the only venue we've created" listed fetchedAgain
-  _ <- deleteVenue handle venue
-  listedAgain <- listVenues handle
+  _ <- Venue.deleteVenue handle venue
+  listedAgain <- Venue.listVenues handle
+                 (Venue.FreeNightFilter $ Postgres.PGArray [Time.Monday .. Time.Sunday])
   assertEqual "the venue is gone from the db" listedAgain []
 
 matchupDBSpec :: Assertion
 matchupDBSpec = do
   handle <- defaultHandle
-  currTime <- now
-  player1 <- (\playerID -> Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
-  player2 <- (\playerID -> Player playerID "bar@absurd.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
-  season <- (\seasonID -> Season seasonID 2019 Summer) <$> UUIDv4.nextRandom
+  currTime <- Time.now
+  player1 <- (\playerID -> Player.Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  player2 <- (\playerID -> Player.Player playerID "bar@absurd.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  season <- (\seasonID -> Season.Season seasonID 2019 Time.Summer) <$> UUIDv4.nextRandom
   matchup <- (\matchupID ->
-                Matchup matchupID (playerID player1) (playerID player2) 4 (seasonID season) Nothing Nothing) <$>
+                Matchup.Matchup
+                matchupID
+                (Player.playerID player1)
+                (Player.playerID player2)
+                4
+                (Season.seasonID season)
+                Nothing
+                Nothing) <$>
              UUIDv4.nextRandom
   venue <- (\venueID ->
-              Venue venueID
+              Venue.Venue venueID
               "Quite Good and Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
-              (Postgres.PGArray [Monday, Tuesday])
+              (Postgres.PGArray [Time.Monday, Time.Tuesday])
               (Just 10.75)) <$> UUIDv4.nextRandom
-  _ <- createSeason handle season
-  _ <- createPlayer handle player1
-  _ <- createPlayer handle player2
-  _ <- createVenue handle venue
-  inserted <- createMatchup handle matchup
-  retrieved <- getMatchup handle (matchupID matchup)
+  otherVenue <- (\venueID ->
+              Venue.Venue venueID
+              "Not Fun Pool Hall"
+              "2670001234"
+              "Somewhere in Center City, Philadelphia, PA"
+              (Postgres.PGArray [Time.Monday, Time.Tuesday])
+              (Just 10.75)) <$> UUIDv4.nextRandom
+  _ <- Season.createSeason handle season
+  _ <- Player.createPlayer handle player1
+  _ <- Player.createPlayer handle player2
+  _ <- Venue.createVenue handle venue
+  _ <- Venue.createVenue handle otherVenue
+  inserted <- Matchup.createMatchup handle matchup
+  retrieved <- Matchup.getMatchup handle (Matchup.matchupID matchup)
   assertEqual "return from fetch is the same as return from insert" inserted retrieved
   assertEqual "return from insert is the matchup we inserted" inserted [matchup]
-  _ <- scheduleMatchup handle (matchup { date = Just currTime })
-  fetchedAgain <- getMatchup handle (matchupID matchup)
+  _ <- Matchup.scheduleMatchup handle (matchup { Matchup.date = Just currTime })
+  fetchedAgain <- Matchup.getMatchup handle (Matchup.matchupID matchup)
   assertEqual "updating just the date shouldn't have changed anything" fetchedAgain [matchup]
-  _ <- scheduleMatchup handle (matchup { date = Just currTime, venue = Just (venueID venue) })
-  fetchedAThirdTime <- getMatchup handle (matchupID matchup)
+  _ <- Matchup.scheduleMatchup handle (matchup { Matchup.date = Just currTime
+                                       , Matchup.venue = Just (Venue.venueID venue) })
+  fetchedAThirdTime <- Matchup.getMatchup handle (Matchup.matchupID matchup)
   assertEqual "updating both date and venue should have set venue"
-    (head . (Data.Ladder.Matchup.venue <$>) $ fetchedAThirdTime)
-    (Just $ venueID venue)
+    (head . (Matchup.venue <$>) $ fetchedAThirdTime)
+    (Just $ Venue.venueID venue)
+  matchupsAtBadPlace <- Matchup.listMatchupsAtVenue
+    handle
+    (Matchup.VenueFilter currTime (Venue.venueID otherVenue))
+  assertEqual "there shouldnt' be any matchups at the bad place" [] matchupsAtBadPlace
+  matchupsAtGoodPlace <- Matchup.listMatchupsAtVenue
+    handle
+    (Matchup.VenueFilter currTime (Venue.venueID venue))
+  assertEqual "there should be a matchup at the good place"
+    [(Matchup.matchupID matchup)] (Matchup.matchupID <$> matchupsAtGoodPlace)
   -- Fails: too much precision before it goes into the db
   -- but uncommenting reveals that it's working, just in a way that's hard to test because of precision
   -- differences on either side of the db boundary
@@ -176,35 +222,49 @@ matchupDBSpec = do
   --   ((head $ date <$> fetchedAThirdTime) >>= toUTCTime)
   --   (Just currTime >>= toUTCTime)
   -- out of datamodel operations because I didn't make a way to increment time, oops
-  upcomingMatchups <- listMatchupsForPlayer handle (playerID player1)
+  upcomingMatchups <- Matchup.listMatchupsForPlayer handle (Player.playerID player1)
   assertEqual "matchup in the past should not be returned in upcoming matchups" upcomingMatchups []
   _ <- Postgres.execute (Database.conn handle)
        [sql|UPDATE matchups SET date = date + interval '7 days' where id = ?; |]
-         (Postgres.Only (matchupID matchup))
-  upcomingMatchups2 <- listMatchupsForPlayer handle (playerID player1)
+         (Postgres.Only (Matchup.matchupID matchup))
+  upcomingMatchups2 <- Matchup.listMatchupsForPlayer handle (Player.playerID player1)
   assertEqual "matchup in the future should be returned in upcoming matchups"
-                       (head . (matchupID <$>) $ upcomingMatchups2)
-                       (matchupID matchup)
-  match1 <- (\matchID -> Match matchID (matchupID matchup) currTime currTime 6 4 True (playerID player1)) <$>
+                       (head . (Matchup.matchupID <$>) $ upcomingMatchups2)
+                       (Matchup.matchupID matchup)
+  match1 <- (\matchID -> Match.Match matchID
+              (Matchup.matchupID matchup)
+              currTime
+              currTime
+              6
+              4
+              True
+              (Player.playerID player1)) <$>
               UUIDv4.nextRandom
-  matchSubmission1 <- submitMatch handle match1
+  matchSubmission1 <- Match.submitMatch handle match1
   assertEqual "setting validated to true should have been ignored"
-         (validated . head <$> matchSubmission1)
+         (Match.validated . head <$> matchSubmission1)
          (Right False)
-  attempt2 <- submitMatch handle match1
+  attempt2 <- Match.submitMatch handle match1
   assertEqual "users shouldn't be able to submit matches twice" (Left MatchAlreadySubmitted) attempt2
   -- player2 accidentally submits the scores backward
-  match2 <- (\matchID -> Match matchID (matchupID matchup) currTime currTime 4 6 True (playerID player2)) <$>
+  match2 <- (\matchID -> Match.Match matchID
+              (Matchup.matchupID matchup)
+              currTime
+              currTime
+              4
+              6
+              True
+              (Player.playerID player2)) <$>
               UUIDv4.nextRandom
-  matchSubmission2 <- submitMatch handle match2
-  match1Fetched <- getMatch handle (matchID match1)
-  assertEqual "match1 still shouldn't be valid" (_validated $ head match1Fetched) False
-  assertEqual "match2 should also be invalid" (validated . head <$> matchSubmission2) (Right False)
-  _ <- updateMatch handle (match2 { player1Wins = 6, player2Wins = 4 })
-  match1FetchedAgain <- getMatch handle (matchID match1)
-  match2Fetched <- getMatch handle (matchID match2)
-  assertEqual "match1 should be valid" (_validated $ head match1FetchedAgain) True
-  assertEqual "match2 should also be valid" (_validated $ head match2Fetched) True
-  _ <- deleteMatchup handle matchup
-  fetchedAFourthTime <- getMatchup handle (matchupID matchup)
+  matchSubmission2 <- Match.submitMatch handle match2
+  match1Fetched <- Match.getMatch handle (Match.matchID match1)
+  assertEqual "match1 still shouldn't be valid" (Match._validated $ head match1Fetched) False
+  assertEqual "match2 should also be invalid" (Match.validated . head <$> matchSubmission2) (Right False)
+  _ <- Match.updateMatch handle (match2 { Match.player1Wins = 6, Match.player2Wins = 4 })
+  match1FetchedAgain <- Match.getMatch handle (Match.matchID match1)
+  match2Fetched <- Match.getMatch handle (Match.matchID match2)
+  assertEqual "match1 should be valid" (Match._validated $ head match1FetchedAgain) True
+  assertEqual "match2 should also be valid" (Match._validated $ head match2Fetched) True
+  _ <- Matchup.deleteMatchup handle matchup
+  fetchedAFourthTime <- Matchup.getMatchup handle (Matchup.matchupID matchup)
   assertEqual "the matchup is gone from the db" fetchedAFourthTime []

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -150,7 +150,7 @@ venueDBSpec = do
     [venue { Venue.name = "Actually Not a Fun Place"
            , Venue.leagueNights = Postgres.PGArray [Time.Monday, Time.Tuesday]}]
   listed <- Venue.listVenues handle
-            (Postgres.PGArray [Time.Wednesday .. Time.Sunday])
+            (Postgres.PGArray [Time.Monday, Time.Tuesday])
   assertEqual "list should get the only venue we've created" listed fetchedAgain
   _ <- Venue.deleteVenue handle venue
   listedAgain <- Venue.listVenues handle

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -150,11 +150,11 @@ venueDBSpec = do
     [venue { Venue.name = "Actually Not a Fun Place"
            , Venue.leagueNights = Postgres.PGArray [Time.Monday, Time.Tuesday]}]
   listed <- Venue.listVenues handle
-            (Venue.FreeNightFilter $ Postgres.PGArray [Time.Wednesday .. Time.Sunday])
+            (Postgres.PGArray [Time.Wednesday .. Time.Sunday])
   assertEqual "list should get the only venue we've created" listed fetchedAgain
   _ <- Venue.deleteVenue handle venue
   listedAgain <- Venue.listVenues handle
-                 (Venue.FreeNightFilter $ Postgres.PGArray [Time.Monday .. Time.Sunday])
+                 (Postgres.PGArray [Time.Monday .. Time.Sunday])
   assertEqual "the venue is gone from the db" listedAgain []
 
 matchupDBSpec :: Assertion


### PR DESCRIPTION
Overview
-----

This PR makes venue filtering for league nights work and hooks up the first API endpoint.

Notes
-----

There are a few unimplemented things here in the venue API. They're based on as-yet-undocumented work coming out of #8.

Testing
-----

- add two venues to the database with different league nights
- query for them based on some `freeNights==` queries in httpie