### PR TITLE
Add proposed match CRUD

### DIFF
--- a/ladder.cabal
+++ b/ladder.cabal
@@ -18,6 +18,7 @@ library
   exposed-modules:     Data.Ladder.Match
                      , Data.Ladder.Matchup
                      , Data.Ladder.Player
+                     , Data.Ladder.ProposedMatch
                      , Data.Ladder.Rating
                      , Data.Ladder.Season
                      , Data.Ladder.Time
@@ -26,6 +27,7 @@ library
                      , Database.Ladder.Match
                      , Database.Ladder.Matchup
                      , Database.Ladder.Player
+                     , Database.Ladder.ProposedMatch
                      , Database.Ladder.Rating
                      , Database.Ladder.Season
                      , Database.Ladder.Venue

--- a/migrations/2019-01-01T17:53:58_create-proposed-matches.sql
+++ b/migrations/2019-01-01T17:53:58_create-proposed-matches.sql
@@ -1,0 +1,16 @@
+-- rambler up
+
+CREATE TABLE proposed_matches (
+  id uuid primary key,
+  matchup uuid references matchups(id) not null,
+  proposed_by uuid references players(id) not null,
+  venue uuid references venues(id) not null,
+  match_time timestamp with time zone not null,
+  accepted boolean not null,
+  canceled boolean not null
+);
+
+-- rambler down
+
+DROP TABLE proposed_matches;
+

--- a/src/Data/Ladder/ProposedMatch.hs
+++ b/src/Data/Ladder/ProposedMatch.hs
@@ -1,0 +1,16 @@
+module Data.Ladder.ProposedMatch ( ProposedMatch (..) ) where
+
+import Data.UUID (UUID)
+import qualified Data.Ladder.Time as Time
+import GHC.Generics (Generic)
+import qualified Database.PostgreSQL.Simple.FromRow as Postgres
+import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
+
+data ProposedMatch = ProposedMatch { proposedMatchID :: UUID
+                                   , matchup :: UUID
+                                   , proposedBy :: UUID
+                                   , venue :: UUID
+                                   , matchTime :: Time.SqlTime } deriving (Eq, Show, Generic)
+
+instance Postgres.ToRow ProposedMatch
+instance Postgres.FromRow ProposedMatch

--- a/src/Data/Ladder/ProposedMatch.hs
+++ b/src/Data/Ladder/ProposedMatch.hs
@@ -1,16 +1,16 @@
 module Data.Ladder.ProposedMatch ( ProposedMatch (..) ) where
 
-import Data.UUID (UUID)
-import qualified Data.Ladder.Time as Time
-import GHC.Generics (Generic)
+import qualified Data.Ladder.Time                   as Time
+import           Data.UUID                          (UUID)
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
 import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
+import           GHC.Generics                       (Generic)
 
 data ProposedMatch = ProposedMatch { proposedMatchID :: UUID
-                                   , matchup :: UUID
-                                   , proposedBy :: UUID
-                                   , venue :: UUID
-                                   , matchTime :: Time.SqlTime } deriving (Eq, Show, Generic)
+                                   , matchup         :: UUID
+                                   , proposedBy      :: UUID
+                                   , venue           :: UUID
+                                   , matchTime       :: Time.SqlTime } deriving (Eq, Show, Generic)
 
 instance Postgres.ToRow ProposedMatch
 instance Postgres.FromRow ProposedMatch

--- a/src/Database/Ladder/ProposedMatch.hs
+++ b/src/Database/Ladder/ProposedMatch.hs
@@ -1,0 +1,60 @@
+module Database.Ladder.ProposedMatch ( getProposedMatch
+                                     , proposeMatch
+                                     , acceptMatch
+                                     , cancelMatch
+                                     , listProposedMatches ) where
+
+import qualified Database.Ladder                  as Database
+import qualified Database.PostgreSQL.Simple       as Postgres
+
+import           Data.Int                         (Int64)
+import           Data.Ladder.ProposedMatch
+import           Data.UUID                        (UUID)
+import qualified Database.Ladder                  as Database
+import qualified Database.PostgreSQL.Simple       as Postgres
+import           Database.PostgreSQL.Simple.SqlQQ
+
+getProposedMatch :: Database.Handle -> UUID -> IO [ProposedMatch]
+getProposedMatch handle proposedMatchID =
+  let
+    fetchQuery = [sql|SELECT id, matchup, proposed_by, venue, match_time, accepted
+                     FROM proposed_matches
+                     WHERE id = ?;|]
+  in
+    Postgres.query (Database.conn handle) fetchQuery (Postgres.Only proposedMatchID)
+
+proposeMatch :: Database.Handle -> ProposedMatch -> IO [ProposedMatch]
+proposeMatch handle proposedMatch =
+  let
+    insertQuery = [sql|INSERT INTO proposed_matches (id, matchup, proposed_by, venue, match_time, accepted, canceled)
+                      VALUES (?, ?, ?, ?, ?, false, false)
+                      RETURNING id, matchup, proposed_by, venue, match_time; |]
+  in
+    Postgres.query (Database.conn handle) insertQuery proposedMatch
+
+acceptMatch :: Database.Handle -> ProposedMatch -> IO Int64
+acceptMatch handle proposedMatch =
+  let
+    updateQuery = [sql|UPDATE proposed_matches SET accepted = true WHERE id = ?;|]
+    cancelQuery = [sql|UPDATE proposed_matches SET canceled = true
+                      WHERE id = ? AND matchup = ?; |]
+  in
+    Postgres.execute (Database.conn handle) updateQuery (Postgres.Only (proposedMatchID proposedMatch)) <*
+    Postgres.execute (Database.conn handle) cancelQuery (proposedMatchID proposedMatch, matchup proposedMatch)
+
+cancelMatch :: Database.Handle -> UUID -> IO Int64
+cancelMatch handle proposedMatchID =
+  let
+    cancelQuery = [sql|UPDATE proposed_matches SET cancled = true
+                      WHERE id = ?; |]
+  in
+    Postgres.execute (Database.conn handle) cancelQuery (Postgres.Only proposedMatchID)
+
+listProposedMatches :: Database.Handle -> UUID -> IO [ProposedMatch]
+listProposedMatches handle matchupID =
+  let
+    listQuery = [sql|SELECT id, matchup, proposed_by, venue, match_time
+                    FROM proposed_matches
+                    WHERE matchup = ? AND canceled = false; |]
+  in
+    Postgres.query (Database.conn handle) listQuery (Postgres.Only matchupID)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ import           Data.Int                         (Int64)
 import qualified Data.Ladder.Match                as Match
 import qualified Data.Ladder.Matchup              as Matchup
 import qualified Data.Ladder.Player               as Player
+import qualified Data.Ladder.ProposedMatch        as ProposedMatch
 import qualified Data.Ladder.Rating               as Rating
 import qualified Data.Ladder.Season               as Season
 import qualified Data.Ladder.Time                 as Time
@@ -13,6 +14,7 @@ import qualified Database.Ladder                  as Database
 import qualified Database.Ladder.Match            as Match
 import qualified Database.Ladder.Matchup          as Matchup
 import qualified Database.Ladder.Player           as Player
+import qualified Database.Ladder.ProposedMatch    as ProposedMatch
 import qualified Database.Ladder.Rating           as Rating
 import qualified Database.Ladder.Season           as Season
 import qualified Database.Ladder.Venue            as Venue
@@ -66,6 +68,7 @@ dbSpec = do
   ratingDBSpec
   venueDBSpec
   matchupDBSpec
+  proposedMatchDBSpec
 
 seasonDBSpec :: Assertion
 seasonDBSpec = do
@@ -268,3 +271,58 @@ matchupDBSpec = do
   _ <- Matchup.deleteMatchup handle matchup
   fetchedAFourthTime <- Matchup.getMatchup handle (Matchup.matchupID matchup)
   assertEqual "the matchup is gone from the db" fetchedAFourthTime []
+
+proposedMatchDBSpec :: Assertion
+proposedMatchDBSpec = do
+  handle <- defaultHandle
+  currTime <- Time.now
+  venue <- (\venueID ->
+              Venue.Venue venueID
+              "Quite Good and Fun Pool Hall"
+              "2670001234"
+              "Somewhere in Center City, Philadelphia, PA"
+              (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
+              (Just 10.75)) <$> UUIDv4.nextRandom
+  otherVenue <- (\venueID ->
+              Venue.Venue venueID
+              "Not Fun Pool Hall"
+              "2670001234"
+              "Somewhere in Center City, Philadelphia, PA"
+              (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
+              (Just 10.75)) <$> UUIDv4.nextRandom
+  player1 <- (\playerID -> Player.Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  player2 <- (\playerID -> Player.Player playerID "bar@absurd.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
+  season <- (\seasonID -> Season.Season seasonID 2019 Time.Summer) <$> UUIDv4.nextRandom
+  matchup <- (\matchupID ->
+                Matchup.Matchup
+                matchupID
+                (Player.playerID player1)
+                (Player.playerID player2)
+                4
+                (Season.seasonID season)
+                Nothing
+                Nothing) <$>
+             UUIDv4.nextRandom
+  proposedMatch1 <- (\pmID -> ProposedMatch.ProposedMatch
+                      pmID
+                      (Matchup.matchupID matchup)
+                      (Player.playerID player1)
+                      (Venue.venueID venue)
+                      currTime
+                    ) <$> UUIDv4.nextRandom
+  proposedMatch2 <- (\pmID -> ProposedMatch.ProposedMatch
+                      pmID
+                      (Matchup.matchupID matchup)
+                      (Player.playerID player1)
+                      (Venue.venueID venue)
+                      currTime
+                    ) <$> UUIDv4.nextRandom
+  _ <- Season.createSeason handle season
+  _ <- Venue.createVenue handle venue
+  _ <- Venue.createVenue handle otherVenue
+  _ <- Player.createPlayer handle player1
+  _ <- Player.createPlayer handle player2
+  _ <- Matchup.createMatchup handle matchup
+  _ <- ProposedMatch.proposeMatch handle proposedMatch1
+  _ <- ProposedMatch.proposeMatch handle proposedMatch2
+  print "lol"


### PR DESCRIPTION
Overview
-----

This PR adds proposed matches as a data model as an intermediate step between matchups and matches.

Testing
-----

tests

Closes #22 