### PR TITLE
Add auth to venue search

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -227,3 +227,5 @@ newline: native
 language_extensions:
   - TemplateHaskell
   - QuasiQuotes
+  - DataKinds
+  - TypeOperators

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,23 +1,26 @@
 module Config where
 
+import           Crypto.JOSE.JWK
 import           Data.ByteString            (ByteString)
 import           Data.ByteString.Char8      (pack)
 import           Data.Maybe                 (fromMaybe)
 import           Database.Ladder            (Handle (..))
 import qualified Database.PostgreSQL.Simple as Postgres
+import           Servant.Auth.Server
 import           System.Environment         (lookupEnv)
 
-data Config = Config { connString :: ByteString } deriving (Show)
+data Config = Config { connString :: ByteString
+                     , jwk        :: JWK} deriving (Show)
 
 defaultConfig :: IO Config
 defaultConfig = do
+  -- db settings
   user <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_USER"
   pass <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_PASSWORD"
   host <- fromMaybe "localhost" <$> lookupEnv "POSTGRES_HOST"
   port <- (read :: String -> Int) . fromMaybe "5432" <$> lookupEnv "POSTGRES_PORT"
   name <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_NAME"
-  return . Config $
-    pack $
+  connString <- return . pack $
     "postgresql://" ++ user ++
     ":" ++
     pass ++
@@ -27,6 +30,9 @@ defaultConfig = do
     show port ++
     "/" ++
     name
+  -- JWT settings
+  jwk <- generateKey
+  return $ Config connString jwk
 
 defaultHandle :: IO Handle
 defaultHandle = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,8 @@
 module Main where
 
-import Network.Wai
-import Network.Wai.Handler.Warp
-import Server
+import           Network.Wai
+import           Network.Wai.Handler.Warp
+import           Server
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,4 +5,6 @@ import Network.Wai.Handler.Warp
 import Server
 
 main :: IO ()
-main = run 8081 application
+main = do
+  app <- application
+  run 8081 app

--- a/app/Server.hs
+++ b/app/Server.hs
@@ -1,11 +1,26 @@
 module Server where
 
-import Data.Ladder.Time
-import Server.Venue
-import Servant
+import           Config
+import           Data.Ladder.Time
+import           Servant
+import           Servant.Auth.Server
+import           Server.Token
+import           Server.Venue
 
-api :: Proxy VenueAPI
+type LadderAPI =
+  VenueAPI :<|> TokenAPI
+
+api :: Proxy LadderAPI
 api = Proxy
 
-application :: Application
-application = serve api venueServer
+server :: Server LadderAPI
+server =
+  venueServer :<|>
+  tokenServer
+
+application :: IO Application
+application = do
+  key <- jwk <$> defaultConfig
+  jwtSettings <- pure $ defaultJWTSettings key
+  cfg <- pure $  jwtSettings :. defaultCookieSettings :. EmptyContext
+  return $ serveWithContext api cfg server

--- a/app/Server.hs
+++ b/app/Server.hs
@@ -13,14 +13,14 @@ type LadderAPI =
 api :: Proxy LadderAPI
 api = Proxy
 
-server :: Server LadderAPI
-server =
+server :: JWTSettings -> Server LadderAPI
+server settings =
   venueServer :<|>
-  tokenServer
+  tokenServer settings
 
 application :: IO Application
 application = do
   key <- jwk <$> defaultConfig
   jwtSettings <- pure $ defaultJWTSettings key
   cfg <- pure $  jwtSettings :. defaultCookieSettings :. EmptyContext
-  return $ serveWithContext api cfg server
+  return $ serveWithContext api cfg (server jwtSettings)

--- a/app/Server/Token.hs
+++ b/app/Server/Token.hs
@@ -1,0 +1,38 @@
+module Server.Token (TokenAPI (..), tokenServer) where
+
+import           Config
+import           Control.Monad.IO.Class     (MonadIO (..))
+import           Data.Aeson
+import           Data.ByteString.Char8      (unpack)
+import           Data.ByteString.Lazy       (toStrict)
+import           Data.Ladder.ClientInfo     (ClientInfo (..))
+import           Data.Ladder.Player         (Player (..))
+import           Database.Ladder.ClientInfo
+import           GHC.Generics               (Generic)
+import           Servant
+import qualified Servant.Auth.Server        as SAS
+import           Servant.Server
+
+
+data TokenResp = TokenResp { key :: String } deriving (Eq, Show, Generic)
+instance ToJSON TokenResp
+
+type TokenAPI =
+  "token"
+  :> ReqBody '[JSON] ClientInfo
+  :> Post '[JSON] TokenResp
+
+tokenPostHandler :: ClientInfo -> Handler TokenResp
+tokenPostHandler clientInfo = do
+  handle <- liftIO defaultHandle
+  key <- liftIO $ jwk <$> defaultConfig
+  jwtSettings <- pure $ SAS.defaultJWTSettings key
+  jwtResult <- liftIO $ getJWT handle jwtSettings clientInfo
+  case jwtResult of
+    Right key ->
+      pure $ TokenResp (unpack . toStrict $ key)
+    Left _ ->
+      error "Could not get JWT from user and pass"
+
+tokenServer :: Server TokenAPI
+tokenServer = tokenPostHandler

--- a/app/Server/Venue.hs
+++ b/app/Server/Venue.hs
@@ -9,7 +9,7 @@ import           Data.Maybe                       (fromMaybe)
 import           Database.Ladder.Venue
 import qualified Database.PostgreSQL.Simple.Types as Postgres
 import           Servant
-import           Servant.Auth.Server
+import qualified Servant.Auth.Server              as SAS
 import           Servant.Server
 
 
@@ -18,7 +18,7 @@ import           Data.UUID                        (UUID)
 import           Debug.Trace
 
 type VenueAPI =
-  Auth '[JWT] Player :> "venues" :> QueryParam "freeNights" [Time.DayOfWeek] :> Get '[JSON] [Venue]
+  SAS.Auth '[SAS.JWT] Player :> "venues" :> QueryParam "freeNights" [Time.DayOfWeek] :> Get '[JSON] [Venue]
   -- :<|> "venues" :> Capture "venueID" UUID :> Get '[JSON] Venue
   -- :<|> "venues" :> Put '[JSON] Int
   -- :<|> "venues" :> Delete '[JSON] Int
@@ -33,5 +33,5 @@ venueListHandler maybeDaysOfWeek = do
       Postgres.PGArray $ fromMaybe Time.allDaysOfWeek maybeDaysOfWeek
 
 venueServer :: Server VenueAPI
-venueServer (Authenticated _) = venueListHandler
-venueServer _                 = throwAll err401
+venueServer (SAS.Authenticated _) = venueListHandler
+venueServer _                     = SAS.throwAll err401

--- a/ladder.cabal
+++ b/ladder.cabal
@@ -92,7 +92,9 @@ test-suite ladder-test
                      , hspec
                      , HUnit
                      , bytestring >= 0.10.8.2 && < 0.11
+                     , jose >= 0.7.0.0 && < 0.8
                      , postgresql-simple >= 0.5.4.0 && < 0.6
+                     , servant-auth-server
                      , time >= 1.8.0.2 && < 1.9
                      , uuid >= 1.3.13 && < 1.4
   other-modules:       Config

--- a/ladder.cabal
+++ b/ladder.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Data.Ladder.Match
+  exposed-modules:     Data.Ladder.ClientInfo
+                     , Data.Ladder.Match
                      , Data.Ladder.Matchup
                      , Data.Ladder.Player
                      , Data.Ladder.ProposedMatch
@@ -24,6 +25,7 @@ library
                      , Data.Ladder.Time
                      , Data.Ladder.Venue
                      , Database.Ladder
+                     , Database.Ladder.ClientInfo
                      , Database.Ladder.Match
                      , Database.Ladder.Matchup
                      , Database.Ladder.Player
@@ -35,15 +37,19 @@ library
                      , Rating
   build-depends:       base >= 4.7 && < 5
                      , aeson
+                     , bcrypt >= 0.0.11 && < 0.0.12
                      , bytestring >= 0.10.8.2 && < 0.11
-                     , servant-server
                      , postgresql-simple >= 0.5.4.0 && < 0.6
+                     , servant-server
+                     , servant-auth
+                     , servant-auth-server
                      , statistics >= 0.14.0.2 && < 0.15
                      , text
                      , time >= 1.8.0.2 && < 1.9
                      , uuid >= 1.3.13 && < 1.4
                      , wai
                      , warp
+                     , wreq
   default-language:    Haskell2010
   default-extensions:  DeriveGeneric
                      , OverloadedStrings
@@ -57,11 +63,15 @@ executable ladder-exe
   other-modules:       Config
                      , Server
                      , Server.Venue
+                     , Server.Token
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , ladder
+                     , aeson
+                     , servant-auth-server
                      , servant-server
+                     , jose >= 0.7.0.0 && < 0.8
                      , bytestring >= 0.10.8.2 && < 0.11
                      , postgresql-simple >= 0.5.4.0 && < 0.6
                      , servant-server
@@ -71,6 +81,7 @@ executable ladder-exe
   default-language:    Haskell2010
   default-extensions:  DataKinds
                      , TypeOperators
+                     , DeriveGeneric
 
 test-suite ladder-test
   type:                exitcode-stdio-1.0

--- a/ladder.cabal
+++ b/ladder.cabal
@@ -70,7 +70,6 @@ executable ladder-exe
                      , ladder
                      , aeson
                      , servant-auth-server
-                     , servant-server
                      , jose >= 0.7.0.0 && < 0.8
                      , bytestring >= 0.10.8.2 && < 0.11
                      , postgresql-simple >= 0.5.4.0 && < 0.6

--- a/migrations/2019-01-04T18:37:20_add-client-info-table.sql
+++ b/migrations/2019-01-04T18:37:20_add-client-info-table.sql
@@ -1,0 +1,11 @@
+-- rambler up
+
+CREATE TABLE client_info (
+  player uuid references players(id) not null,
+  password varchar(255) not null
+);
+
+-- rambler down
+
+DROP TABLE client_info;
+

--- a/src/Data/Ladder/ClientInfo.hs
+++ b/src/Data/Ladder/ClientInfo.hs
@@ -1,0 +1,9 @@
+module Data.Ladder.ClientInfo (ClientInfo (..))where
+
+import           Data.Aeson
+import           GHC.Generics (Generic)
+
+data ClientInfo = ClientInfo { email :: String
+                             , pass  :: String } deriving (Eq, Show, Generic)
+
+instance FromJSON ClientInfo

--- a/src/Data/Ladder/Player.hs
+++ b/src/Data/Ladder/Player.hs
@@ -1,9 +1,11 @@
 module Data.Ladder.Player ( Player (..), playerToUpdate ) where
 
+import           Data.Aeson
 import           Data.UUID                          (UUID)
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
 import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
 import           GHC.Generics                       (Generic)
+import           Servant.Auth.Server
 
 data Player = Player { playerID         :: UUID
                      , email            :: String
@@ -13,6 +15,10 @@ data Player = Player { playerID         :: UUID
 
 instance Postgres.FromRow Player
 instance Postgres.ToRow Player
+instance ToJSON Player
+instance FromJSON Player
+instance ToJWT Player
+instance FromJWT Player
 
 {- Player records for update queries
 

--- a/src/Data/Ladder/Player.hs
+++ b/src/Data/Ladder/Player.hs
@@ -35,7 +35,7 @@ instance Postgres.ToRow PlayerUpdate
 
 playerToUpdate :: Player -> PlayerUpdate
 playerToUpdate player = PlayerUpdate { _email = email player
-                               , _first = firstName player
-                               , _last = lastName player
-                               , _accepting = acceptingMatches player
-                               , _playerID = playerID player }
+                                     , _first = firstName player
+                                     , _last = lastName player
+                                     , _accepting = acceptingMatches player
+                                     , _playerID = playerID player }

--- a/src/Data/Ladder/Player.hs
+++ b/src/Data/Ladder/Player.hs
@@ -1,7 +1,8 @@
-module Data.Ladder.Player ( Player (..), playerToUpdate ) where
+module Data.Ladder.Player ( Player (..), playerToUpdate, makePlayer ) where
 
 import           Data.Aeson
 import           Data.UUID                          (UUID)
+import qualified Data.UUID.V4                       as UUIDv4
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
 import qualified Database.PostgreSQL.Simple.ToRow   as Postgres
 import           GHC.Generics                       (Generic)
@@ -39,3 +40,7 @@ playerToUpdate player = PlayerUpdate { _email = email player
                                      , _last = lastName player
                                      , _accepting = acceptingMatches player
                                      , _playerID = playerID player }
+
+makePlayer :: String -> String -> String -> IO Player
+makePlayer e f l =
+  (\x -> Player x e f l False) <$> UUIDv4.nextRandom

--- a/src/Database/Ladder/ClientInfo.hs
+++ b/src/Database/Ladder/ClientInfo.hs
@@ -19,12 +19,11 @@ import           Servant.Auth.Server              (JWTSettings, makeJWT)
 storePassword :: Database.Handle -> ClientInfo -> IO Int64
 storePassword handle info =
   let
-    userFetchQuery = [sql|SELECT id FROM users WHERE email = ?;|]
-    passInsertQuery = [sql|INSERT INTO client_info (user_id, password) VALUES (?, ?);|]
+    passInsertQuery = [sql|INSERT INTO client_info (player, password) VALUES (?, ?);|]
   in
     do
       encrypted <- hashPasswordUsingPolicy fastBcryptHashingPolicy (pack . pass $ info)
-      users <- Postgres.query (Database.conn handle) userFetchQuery (Postgres.Only $ email info)
+      users <- Player.getPlayerByEmail handle (email info)
       case users of
         (x : []) ->
           Postgres.execute (Database.conn handle) passInsertQuery (Player.playerID x, encrypted)
@@ -33,7 +32,9 @@ storePassword handle info =
 getJWT :: Database.Handle -> JWTSettings -> ClientInfo -> IO (Either Message ByteString)
 getJWT handle settings info =
   let
-    passFetchQuery = [sql|SELECT password FROM client_info WHERE player_id = ?;|]
+    -- It's stupid to select the 1, but it keeps the type mapping from getting weird,
+    -- so :man_shrugging:
+    passFetchQuery = [sql|SELECT password, 1 FROM client_info WHERE player = ?;|]
   in
     do
       users <- Player.getPlayerByEmail handle (email info)
@@ -42,9 +43,9 @@ getJWT handle settings info =
           pure $ Left BadPassword
         (x : []) ->
           do
-            userPass <- head <$>
+            (userPass, _) <- head <$>
               (Postgres.query (Database.conn handle) passFetchQuery (Postgres.Only $ Player.playerID x)
-               :: IO [String])
+               :: IO [(String, Int)])
             if (validatePassword (pack userPass) (pack . pass $ info)) then
               left (const BadPassword) <$> makeJWT x settings Nothing
             else

--- a/src/Database/Ladder/ClientInfo.hs
+++ b/src/Database/Ladder/ClientInfo.hs
@@ -1,0 +1,53 @@
+module Database.Ladder.ClientInfo ( storePassword
+                                  , getJWT ) where
+
+import           Control.Arrow                    (left)
+import           Crypto.BCrypt
+import           Data.ByteString.Char8            (pack, unpack)
+import           Data.ByteString.Lazy             (ByteString)
+import           Data.Int                         (Int64)
+import           Data.Ladder.ClientInfo
+import qualified Data.Ladder.Player               as Player
+import           Data.UUID                        (UUID)
+import qualified Database.Ladder                  as Database
+import qualified Database.Ladder.Player           as Player
+import qualified Database.PostgreSQL.Simple       as Postgres
+import           Database.PostgreSQL.Simple.SqlQQ
+import           Error
+import           Servant.Auth.Server              (JWTSettings, makeJWT)
+
+storePassword :: Database.Handle -> ClientInfo -> IO Int64
+storePassword handle info =
+  let
+    userFetchQuery = [sql|SELECT id FROM users WHERE email = ?;|]
+    passInsertQuery = [sql|INSERT INTO client_info (user_id, password) VALUES (?, ?);|]
+  in
+    do
+      encrypted <- hashPasswordUsingPolicy fastBcryptHashingPolicy (pack . pass $ info)
+      users <- Postgres.query (Database.conn handle) userFetchQuery (Postgres.Only $ email info)
+      case users of
+        (x : []) ->
+          Postgres.execute (Database.conn handle) passInsertQuery (Player.playerID x, encrypted)
+        _ -> pure 0
+
+getJWT :: Database.Handle -> JWTSettings -> ClientInfo -> IO (Either Message ByteString)
+getJWT handle settings info =
+  let
+    passFetchQuery = [sql|SELECT password FROM client_info WHERE player_id = ?;|]
+  in
+    do
+      users <- Player.getPlayerByEmail handle (email info)
+      case users of
+        [] ->
+          pure $ Left BadPassword
+        (x : []) ->
+          do
+            userPass <- head <$>
+              (Postgres.query (Database.conn handle) passFetchQuery (Postgres.Only $ Player.playerID x)
+               :: IO [String])
+            if (validatePassword (pack userPass) (pack . pass $ info)) then
+              left (const BadPassword) <$> makeJWT x settings Nothing
+            else
+              pure $ Left BadPassword
+        _ ->
+          pure $ Left BadPassword

--- a/src/Database/Ladder/Matchup.hs
+++ b/src/Database/Ladder/Matchup.hs
@@ -13,8 +13,6 @@ import qualified Database.Ladder                  as Database
 import qualified Database.PostgreSQL.Simple       as Postgres
 import           Database.PostgreSQL.Simple.SqlQQ
 
-import Debug.Trace
-
 getMatchup :: Database.Handle -> UUID -> IO [Matchup]
 getMatchup handle matchupID =
   let
@@ -67,4 +65,4 @@ listMatchupsAtVenue handle filter =
                     FROM matchups
                     WHERE date(date) = date(?) AND venue = ?;|]
   in
-    Postgres.query (Database.conn handle) listQuery ((trace $ "filters are " ++ show filter) filter)
+    Postgres.query (Database.conn handle) listQuery filter

--- a/src/Database/Ladder/Player.hs
+++ b/src/Database/Ladder/Player.hs
@@ -1,4 +1,5 @@
 module Database.Ladder.Player ( getPlayer
+                              , getPlayerByEmail
                               , createPlayer
                               , updatePlayer
                               , deletePlayer
@@ -19,6 +20,15 @@ getPlayer handle playerID =
                      WHERE id = ?;|]
   in
     Postgres.query (Database.conn handle) fetchQuery (Postgres.Only playerID)
+
+getPlayerByEmail :: Database.Handle -> String -> IO [Player]
+getPlayerByEmail handle email =
+  let
+    fetchQuery = [sql|SELECT id, email, first_name, last_name, accepting_matches
+                     FROM players
+                     WHERE email = ?;|]
+  in
+    Postgres.query (Database.conn handle) fetchQuery (Postgres.Only email)
 
 createPlayer :: Database.Handle -> Player -> IO [Player]
 createPlayer handle player =

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -4,4 +4,5 @@ data Message =
   UnbalancedMatch String
   | NotYourMatch
   | MatchAlreadySubmitted
+  | BadPassword
   deriving (Eq, Show)

--- a/test/Config.hs
+++ b/test/Config.hs
@@ -1,13 +1,42 @@
-module Config (defaultHandle) where
+module Config (Config (..), defaultHandle, defaultConfig) where
 
+import           Crypto.JOSE.JWK
 import           Data.ByteString            (ByteString)
+import           Data.ByteString.Char8      (pack)
+import           Data.Maybe                 (fromMaybe)
 import           Database.Ladder            (Handle (..))
 import qualified Database.PostgreSQL.Simple as Postgres
+import           Servant.Auth.Server
+import           System.Environment         (lookupEnv)
 
-connString :: ByteString
-connString = "postgresql://ladder:ladder@localhost:5432/ladder_test"
+data Config = Config { connString :: ByteString
+                     , jwk        :: JWK} deriving (Show)
+
+
+defaultConfig :: IO Config
+defaultConfig = do
+  -- db settings
+  user <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_USER"
+  pass <- fromMaybe "ladder" <$> lookupEnv "POSTGRES_PASSWORD"
+  host <- fromMaybe "localhost" <$> lookupEnv "POSTGRES_HOST"
+  port <- (read :: String -> Int) . fromMaybe "5432" <$> lookupEnv "POSTGRES_PORT"
+  name <- fromMaybe "ladder_test" <$> lookupEnv "POSTGRES_NAME"
+  connString <- return . pack $
+    "postgresql://" ++ user ++
+    ":" ++
+    pass ++
+    "@" ++
+    host ++
+    ":" ++
+    show port ++
+    "/" ++
+    name
+  -- JWT settings
+  jwk <- generateKey
+  return $ Config connString jwk
+
 
 defaultHandle :: IO Handle
 defaultHandle = do
-  conn <- Postgres.connectPostgreSQL connString
-  return $ Handle conn
+  cs <-  connString <$> defaultConfig
+  Handle <$> Postgres.connectPostgreSQL cs


### PR DESCRIPTION
Overview
-----

This PR adds JWT authentication and some peripheral things to make venue search require having a user/password.

Notes
-----

I had some trouble at first with the JWTs, because `defaultConfig :: IO Config` isn't memoized by default. Thinking about [build-in memoization](https://hackage.haskell.org/package/io-memoize-1.1.1.0/docs/System-IO-Memoize.html) options as a way around that, but it also made me realize I need a way to share state across instances of the server, unless I want everyone to have to get new tokens any time I have to cycle a running instance. Capturing as #25.

Testing
-----

- use `makePlayer` to make yourself a player with a goofy password
- `storePassword` an email + pass for that player
- start the server (`stack build`, `stack exec ladder-exe`)
- `http :8081/token/` with `user` and `pass` in post body
- `http :8081/venues/` with the JWT you get back

Closes #21 