### PR TITLE
Make match outcomes optional on matches

### DIFF
--- a/migrations/2019-01-20T23:43:19_make-outcomes-optional-on-matches.sql
+++ b/migrations/2019-01-20T23:43:19_make-outcomes-optional-on-matches.sql
@@ -1,0 +1,11 @@
+-- rambler up
+
+ALTER TABLE matches ALTER COLUMN player1_wins DROP NOT NULL;
+ALTER TABLE matches ALTER COLUMN player2_wins DROP NOT NULL;
+
+-- rambler down
+
+ALTER TABLE matches ALTER COLUMN player1_wins SET DEFAULT 0;
+ALTER TABLE matches ALTER COLUMN player1_wins SET NOT NULL;
+ALTER TABLE matches ALTER COLUMN player2_wins SET DEFAULT 0;
+ALTER TABLE matches ALTER COLUMN player2_wins SET NOT NULL;

--- a/src/Data/Ladder/Match.hs
+++ b/src/Data/Ladder/Match.hs
@@ -13,8 +13,8 @@ data Match = Match { matchID     :: UUID
                    , matchup     :: UUID
                    , startTime   :: Time.SqlTime
                    , recorded    :: Time.SqlTime
-                   , player1Wins :: Int
-                   , player2Wins :: Int
+                   , player1Wins :: Maybe Int
+                   , player2Wins :: Maybe Int
                    , validated   :: Bool
                    , submittedBy :: UUID } deriving (Eq, Show, Generic)
 
@@ -24,8 +24,8 @@ instance Postgres.FromRow Match
 data MatchWithRelated = MatchWithRelated { _matchID     :: UUID
                                          , _startTime   :: Time.SqlTime
                                          , _recorded    :: Time.SqlTime
-                                         , _player1Wins :: Int
-                                         , _player2Wins :: Int
+                                         , _player1Wins :: Maybe Int
+                                         , _player2Wins :: Maybe Int
                                          , _validated   :: Bool
                                          , _submittedBy :: UUID
                                          , season       :: UUID
@@ -36,8 +36,8 @@ data MatchWithRelated = MatchWithRelated { _matchID     :: UUID
 instance Postgres.ToRow MatchWithRelated
 instance Postgres.FromRow MatchWithRelated
 
-data MatchUpdate = MatchUpdate { newPlayer1Wins :: Int
-                               , newPlayer2Wins :: Int
+data MatchUpdate = MatchUpdate { newPlayer1Wins :: Maybe Int
+                               , newPlayer2Wins :: Maybe Int
                                , _matchID'      :: UUID } deriving (Eq, Show, Generic)
 
 instance Postgres.ToRow MatchUpdate

--- a/src/Database/Ladder/Match.hs
+++ b/src/Database/Ladder/Match.hs
@@ -73,8 +73,8 @@ submitMatch handle match =
       case validation of
         Right Nothing ->
           Right <$> Postgres.query (Database.conn handle) insertQuery (match { validated = False })
-        Right (Just prior) ->
-          Right <$> if (prior == (player1Wins match, player2Wins match)) then
+        Right (Just (p1, p2)) ->
+          Right <$> if ((Just p1, Just p2) == (player1Wins match, player2Wins match)) then
                       Postgres.query (Database.conn handle) insertQuery (match { validated = True }) <*
                       Postgres.execute (Database.conn handle) updateOtherMatchQuery (matchup match, submittedBy match)
                     else

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -238,8 +238,8 @@ matchupDBSpec = do
               (Matchup.matchupID matchup)
               currTime
               currTime
-              6
-              4
+              (pure 6)
+              (pure 4)
               True
               (Player.playerID player1)) <$>
               UUIDv4.nextRandom
@@ -254,8 +254,8 @@ matchupDBSpec = do
               (Matchup.matchupID matchup)
               currTime
               currTime
-              4
-              6
+              (pure 4)
+              (pure 6)
               True
               (Player.playerID player2)) <$>
               UUIDv4.nextRandom
@@ -263,7 +263,7 @@ matchupDBSpec = do
   match1Fetched <- Match.getMatch handle (Match.matchID match1)
   assertEqual "match1 still shouldn't be valid" (Match._validated $ head match1Fetched) False
   assertEqual "match2 should also be invalid" (Match.validated . head <$> matchSubmission2) (Right False)
-  _ <- Match.updateMatch handle (match2 { Match.player1Wins = 6, Match.player2Wins = 4 })
+  _ <- Match.updateMatch handle (match2 { Match.player1Wins = pure 6, Match.player2Wins = pure 4 })
   match1FetchedAgain <- Match.getMatch handle (Match.matchID match1)
   match2Fetched <- Match.getMatch handle (Match.matchID match2)
   assertEqual "match1 should be valid" (Match._validated $ head match1FetchedAgain) True


### PR DESCRIPTION
Overview
-----

This PR makes it so that you don't have to know how many matches players 1 and 2 have won to create a match.

There's a chain of being from matchup -> proposed match -> scheduled match -> completed match. To accept a match, we have to be able to make the next step, which is impossible as long as `player1Wins` and `player2Wins` are required.

Testing
-----

- tests

Helps with #30 (or will soon at least)