### PR TITLE
Update ratings update calculation and tests

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,8 +24,7 @@ import qualified Database.PostgreSQL.Simple       as Postgres
 import           Database.PostgreSQL.Simple.SqlQQ
 import qualified Database.PostgreSQL.Simple.Types as Postgres
 import           Rating                           (eloUpdateWithConstant,
-                                                   matchSeqLikelihood,
-                                                   matchSeqWinProbability, race,
+                                                   perMatchWinProbability,
                                                    validateMatchup)
 import qualified Servant.Auth.Server              as SAS
 import           Test.Hspec
@@ -43,26 +42,20 @@ pureSpec :: Spec
 pureSpec = do
   describe "Match sequence likelihood calculations" $ do
     it "should think players with equal odds are equally likely to win" $ do
-      round (matchSeqWinProbability 10000 5000 0.5 * 100) `shouldBe` 50
-    it "should think probability is lower with lower per match probabilities" $ do
-      matchSeqWinProbability 10000 5000 0.9 `shouldSatisfy` (\x -> x > matchSeqWinProbability 10000 5000 0.1)
+      perMatchWinProbability 10000 10000 `shouldBe` 0.5
     it "should result in rejections of unfair matches" $ do
       validateMatchup 1000 1000 `shouldBe` Right ()
       validateMatchup 1000 1030 `shouldBe` Right ()
       validateMatchup 1000 1200 `shouldNotBe` Right ()
       validateMatchup 1200 1000 `shouldNotBe` Right ()
-  describe "Post-match likelihood calculation" $ do
-    it "should think even matches are even" $ do
-      matchSeqLikelihood (race - 1) 1000 1000 `shouldSatisfy` (\x -> abs (x - 0.5) < 0.000001)
-    it "should think mostly even matches are also pretty even" $ do
-      matchSeqLikelihood (race - 1) 1001 1000 `shouldSatisfy` (\x -> abs (x - 0.5) < 0.05)
-      matchSeqLikelihood (race - 1) 1000 1001 `shouldSatisfy` (\x -> abs (x - 0.5) < 0.05)
-      matchSeqLikelihood (race - 1) 1010 1000 `shouldSatisfy` (\x -> abs (x - 0.5) < 0.05)
-      matchSeqLikelihood (race - 1) 1000 1010 `shouldSatisfy` (\x -> abs (x - 0.5) < 0.05)
-    it "should think unbalanced matchups are unbalanced" $ do
-      matchSeqLikelihood (race - 1) 1100 1000 `shouldSatisfy` (\x -> x > matchSeqLikelihood (race - 1) 1000 1100)
-    it "should think higher ranked players are more likely to win by a given margin" $ do
-      matchSeqLikelihood 3 1100 1000 `shouldSatisfy` (\x -> x < matchSeqLikelihood 3 1200 1000)
+  describe "Ratings adjustments" $ do
+    -- "https://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details"
+    it "should symmetrically apply rating updates" $ do
+      eloUpdateWithConstant 20 5 0 1000 1000 `shouldBe` (1050, 950)
+      eloUpdateWithConstant 20 0 5 1000 1000 `shouldBe` (950, 1050)
+    -- 1095 vs. 905 is about a 75% chance for the winner per rack
+    it "should not penalize or reward players for performing at expectation" $ do
+      ((\x -> (round $ fst x, round $ snd x)) $ eloUpdateWithConstant 20 3 1 1095 905) `shouldBe` (1095, 905)
 
 dbSpec :: IO ()
 dbSpec = do


### PR DESCRIPTION
Overview
----

This PR updates the elo adjustment calculations to more closely match the example in Wikipedia.
This is nice because it makes it more transparent and doesn't require me to think correctly about counterfactual draws from binomial distributions.