### PR TITLE
Add other venue CRUD routes

### DIFF
--- a/app/Server/Venue.hs
+++ b/app/Server/Venue.hs
@@ -1,11 +1,12 @@
-module Server.Venue where
+module Server.Venue (venueServer, VenueAPI) where
 
 import           Config                           (defaultHandle)
 import           Control.Monad.IO.Class           (MonadIO (..))
+import           Data.Int                         (Int64)
 import           Data.Ladder.Player               (Player)
 import qualified Data.Ladder.Time                 as Time
 import           Data.Ladder.Venue
-import           Data.Maybe                       (fromMaybe)
+import           Data.Maybe                       (fromMaybe, listToMaybe)
 import           Database.Ladder.Venue
 import qualified Database.PostgreSQL.Simple.Types as Postgres
 import           Servant
@@ -18,11 +19,35 @@ import           Data.UUID                        (UUID)
 import           Debug.Trace
 
 type VenueAPI =
-  SAS.Auth '[SAS.JWT] Player :> "venues" :> QueryParam "freeNights" [Time.DayOfWeek] :> Get '[JSON] [Venue]
-  -- :<|> "venues" :> Capture "venueID" UUID :> Get '[JSON] Venue
-  -- :<|> "venues" :> Put '[JSON] Int
-  -- :<|> "venues" :> Delete '[JSON] Int
-  -- :<|> "venues" :> PostCreated '[JSON] [Venue]
+  SAS.Auth '[SAS.JWT] Player :>
+  ("venues" :> QueryParam "freeNights" [Time.DayOfWeek] :> Get '[JSON] [Venue]
+  :<|> "venues" :> Capture "venueID" UUID :> Get '[JSON] (Maybe Venue)
+  :<|> "venues" :> Capture "venueID" UUID :> ReqBody '[JSON] Venue :> Put '[JSON] Int64
+  :<|> "venues" :> ReqBody '[JSON] Venue :> PostCreated '[JSON] (Maybe Venue)
+  )
+
+venueCreateHandler :: Venue -> Handler (Maybe Venue)
+venueCreateHandler venue = liftIO $
+  do
+    handle <- defaultHandle
+    listToMaybe <$> createVenue handle venue
+
+venueUpdateHandler :: UUID -> Venue -> Handler Int64
+venueUpdateHandler venueID updatey =
+  let
+    -- don't allow updating a venue different from the one being PUT
+    sanitized = updatey { venueID = venueID}
+  in
+    liftIO $
+    do
+      handle <- defaultHandle
+      updateVenue handle sanitized
+
+venueDetailHandler :: UUID -> Handler (Maybe Venue)
+venueDetailHandler venueID = liftIO $
+  do
+    handle <- liftIO defaultHandle
+    listToMaybe <$> getVenue handle venueID
 
 venueListHandler :: Maybe [Time.DayOfWeek] -> Handler [Venue]
 venueListHandler maybeDaysOfWeek = do
@@ -33,5 +58,9 @@ venueListHandler maybeDaysOfWeek = do
       Postgres.PGArray $ fromMaybe Time.allDaysOfWeek maybeDaysOfWeek
 
 venueServer :: Server VenueAPI
-venueServer (SAS.Authenticated _) = venueListHandler
+venueServer (SAS.Authenticated _) =
+  venueListHandler
+  :<|> venueDetailHandler
+  :<|> venueUpdateHandler
+  :<|> venueCreateHandler
 venueServer _                     = SAS.throwAll err401

--- a/migrations/2019-02-16T21:09:42_add-is_active-to-venues.sql
+++ b/migrations/2019-02-16T21:09:42_add-is_active-to-venues.sql
@@ -1,0 +1,7 @@
+-- rambler up
+
+ALTER TABLE venues ADD COLUMN is_active boolean NOT NULL DEFAULT 'true';
+
+-- rambler down
+
+ALTER TABLE venues DROP COLUMN is_active;

--- a/src/Data/Ladder/Venue.hs
+++ b/src/Data/Ladder/Venue.hs
@@ -14,7 +14,8 @@ data Venue = Venue { venueID      :: UUID
                    , phone        :: String
                    , address      :: String
                    , leagueNights :: Time.DaysOfWeek
-                   , cost         :: Maybe Double } deriving (Eq, Show, Generic)
+                   , cost         :: Maybe Double
+                   , isActive     :: Bool } deriving (Eq, Show, Generic)
 
 instance Postgres.ToRow Venue
 instance Postgres.FromRow Venue
@@ -22,12 +23,13 @@ instance Postgres.FromRow Venue
 instance ToJSON Venue
 instance FromJSON Venue
 
-data VenueUpdate = VenueUpdate { _name :: String
-                               , _phone :: String
-                               , _address :: String
+data VenueUpdate = VenueUpdate { _name         :: String
+                               , _phone        :: String
+                               , _address      :: String
                                , _leagueNights :: Time.DaysOfWeek
-                               , _cost :: Maybe Double
-                               , _venueID :: UUID } deriving (Eq, Show, Generic)
+                               , _cost         :: Maybe Double
+                               , _isActive     :: Bool
+                               , _venueID      :: UUID } deriving (Eq, Show, Generic)
 
 instance Postgres.ToRow VenueUpdate
 
@@ -37,4 +39,5 @@ venueToUpdate venue = VenueUpdate { _name = name venue
                                   , _address = address venue
                                   , _leagueNights = leagueNights venue
                                   , _cost = cost venue
+                                  , _isActive = isActive venue
                                   , _venueID = venueID venue }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -144,7 +144,8 @@ venueDBSpec = do
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
               (Time.DaysOfWeek $ Postgres.PGArray [])
-              (Just 10.75)) <$> UUIDv4.nextRandom
+              (Just 10.75)
+              True) <$> UUIDv4.nextRandom
   inserted <- Venue.createVenue handle venue
   retrieved <- Venue.getVenue handle (Venue.venueID venue)
   assertEqual "return from fetch is the same as return from insert" inserted retrieved
@@ -187,14 +188,16 @@ matchupDBSpec = do
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
               (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
-              (Just 10.75)) <$> UUIDv4.nextRandom
+              (Just 10.75)
+              True) <$> UUIDv4.nextRandom
   otherVenue <- (\venueID ->
               Venue.Venue venueID
               "Not Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
               (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
-              (Just 10.75)) <$> UUIDv4.nextRandom
+              (Just 10.75)
+              True) <$> UUIDv4.nextRandom
   _ <- Season.createSeason handle season
   _ <- Player.createPlayer handle player1
   _ <- Player.createPlayer handle player2
@@ -286,14 +289,16 @@ proposedMatchDBSpec = do
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
               (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
-              (Just 10.75)) <$> UUIDv4.nextRandom
+              (Just 10.75)
+              True) <$> UUIDv4.nextRandom
   otherVenue <- (\venueID ->
               Venue.Venue venueID
               "Not Fun Pool Hall"
               "2670001234"
               "Somewhere in Center City, Philadelphia, PA"
               (Time.DaysOfWeek $ Postgres.PGArray [Time.Monday, Time.Tuesday])
-              (Just 10.75)) <$> UUIDv4.nextRandom
+              (Just 10.75)
+              True) <$> UUIDv4.nextRandom
   player1 <- (\playerID -> Player.Player playerID "foo@bogus.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
   player2 <- (\playerID -> Player.Player playerID "bar@absurd.com" "Bogus" "Name" True) <$> UUIDv4.nextRandom
   season <- (\seasonID -> Season.Season seasonID 2019 Time.Summer) <$> UUIDv4.nextRandom


### PR DESCRIPTION
Overview
-----

This PR adds the remaining routes to venues for CRUD interaction, minus the delete part.
I opted against including the delete method because I thought that probably shouldn't be exposed to users. The method is still in the database `Venue` model and used in tests, but general users can't delete venues anymore. Instead, they can update them to be "inactive," which is a placeholder for bar owners not liking the league or being closed or whatever.